### PR TITLE
[fix]: route ProTable requests through real hook operations

### DIFF
--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -177,8 +177,8 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
       };
       
       // The hook handles the actual data fetching
-      const operations = (crudActions as any).operations;
-      if (operations?.getList) {
+      const { operations } = crudActions;
+      if (operations.getList) {
         const response = await operations.getList(query);
         return { 
           data: response.data, 

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -166,7 +166,7 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
         current: params.current,
         pageSize: params.pageSize,
         sortBy: Object.keys(sort)[0],
-        sortOrder: Object.values(sort)[0],
+        sortOrder: Object.values(sort)[0] ?? undefined,
         ...filter,
         ...params, // Include search parameters
       };

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -2,7 +2,7 @@ import { PlusOutlined, EllipsisOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-components';
 import { ProTable, ProConfigProvider, enUSIntl } from '@ant-design/pro-components';
 import { Button, Dropdown, Tag, message, Modal, Form, Input, InputNumber, Select, Switch, DatePicker } from 'antd';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type { SortOrder } from 'antd/es/table/interface';
 import { format, parseISO, formatISO } from 'date-fns';
 import dayjs from 'dayjs';
@@ -56,11 +56,6 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
   const [currentRecord, setCurrentRecord] = useState<Partial<T> | null>(null);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [form] = Form.useForm();
-
-  // Load data on mount
-  useEffect(() => {
-    crudActions.refresh();
-  }, []);
 
   // Enhanced columns with better type handling
   const enhancedColumns: ProColumns<T>[] = columns.map((col) => {
@@ -311,7 +306,6 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
           showSizeChanger: true,
           showQuickJumper: true,
         }}
-        loading={crudActions.state.loading}
         rowSelection={rowSelection}
         toolBarRender={() => [
           <Button
@@ -340,10 +334,10 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
                   label: 'Export',
                   disabled: true, // TODO: Implement export
                 },
-                { 
-                  key: 'refresh', 
-                  label: 'Refresh', 
-                  onClick: () => crudActions.refresh() 
+                {
+                  key: 'refresh',
+                  label: 'Refresh',
+                  onClick: () => crudActions.actionRef.current?.reload()
                 },
               ],
             }}
@@ -355,7 +349,7 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
         ]}
         options={{
           setting: { listsHeight: 400 },
-          reload: () => crudActions.refresh(),
+          reload: true,
         }}
         dateFormatter="string"
       />

--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -77,11 +77,14 @@ export type CrudTableActions<T> = {
   create: (data: Partial<T>) => Promise<T | null>;
   update: (id: any, data: Partial<T>) => Promise<T | null>;
   delete: (id: any) => Promise<boolean>;
-  
+
+  // Raw data-source operations, for direct wiring (e.g. ProTable's request)
+  operations: Partial<CrudOperation<T>>;
+
   // Table operations
   setPageSize: (size: number) => void;
   setCurrentPage: (page: number) => void;
-  
+
   // State
   state: CrudState<T>;
   actionRef: React.RefObject<ActionType | null>;
@@ -387,6 +390,7 @@ export const useCrudTable = <T extends Record<string, any>>(
     create,
     update,
     delete: deleteItem,
+    operations,
     setPageSize,
     setCurrentPage,
     state,

--- a/lib/hooks/useLocalStorageCrud.ts
+++ b/lib/hooks/useLocalStorageCrud.ts
@@ -260,6 +260,7 @@ export const useLocalStorageCrud = <T extends Record<string, any>>(
     create,
     update,
     delete: deleteItem,
+    operations,
     setPageSize,
     setCurrentPage,
     state,


### PR DESCRIPTION
Closes #1

## What

- `useCrudTable` now returns the resolved data-source `operations` as part of `CrudTableActions<T>` (typed `Partial<CrudOperation<T>>`, no more `as any`).
- `CrudTable.handleRequest` reaches the real `getList`, so ProTable-driven **search / sort / filters / pagination actually hit the data source** instead of silently falling back to the state snapshot.
- Removed the mount `refresh()` effect — ProTable's `request` already fires on mount, so this was a guaranteed double fetch.
- Toolbar "Refresh" and the built-in reload option now go through `actionRef.reload()` so the request pipeline stays the single source of truth; the controlled `loading` prop was dropped so ProTable shows its own request spinner.
- `useLocalStorageCrud` also returns `operations` to keep fulfilling the shared contract; ProTable's nullable `SortOrder` is coerced to `undefined` before entering `CrudParams`.

## Why

`(crudActions as any).operations` referenced a field the hook never exposed, so `operations?.getList` was always `undefined`. Every request fell through to `crudActions.state.data` — the table only ever re-rendered whatever the mount refresh loaded.

## Verification

- `tsc --p tsconfig.build.json --noEmit` passes.
- `pnpm build:lib` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
