### PR TITLE
[fix]: keep static-data operations stable across renders

### DIFF
--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -158,7 +158,10 @@ const createApiOperations = <T>(config: UseCrudTableConfigApi<T>): CrudOperation
 // Static data operations
 const createStaticOperations = <T>(staticData: T[], keyField: keyof T): CrudOperation<T> => {
   const data = [...staticData];
-  let nextId = Math.max(...data.map(item => Number(item[keyField]) || 0)) + 1;
+  // Math.max() over an empty spread is -Infinity, so guard the empty case
+  let nextId = data.length > 0
+    ? Math.max(...data.map(item => Number(item[keyField]) || 0)) + 1
+    : 1;
 
   return {
     getList: async (params: CrudParams) => {

--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import { message } from 'antd';
 import type { ActionType } from '@ant-design/pro-components';
 
@@ -236,8 +236,10 @@ export const useCrudTable = <T extends Record<string, any>>(
     pageSize: config.defaultPageSize || 10,
   });
 
-  // Create operations based on config
-  const operations = (() => {
+  // Create operations based on config. Memoized on the strategy inputs:
+  // static operations keep their working copy in a closure, so rebuilding
+  // them on every render would silently reset the dataset.
+  const operations = useMemo(() => {
     if ('operations' in config) {
       // Custom operations provided
       return config.operations as CrudOperation<T>;
@@ -250,7 +252,13 @@ export const useCrudTable = <T extends Record<string, any>>(
     } else {
       throw new Error('useCrudTable: Must provide either staticData, api config, or custom operations');
     }
-  })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    'operations' in config ? config.operations : undefined,
+    'staticData' in config ? config.staticData : undefined,
+    'api' in config ? config.api : undefined,
+    rowKey,
+  ]);
 
   const refresh = useCallback(async () => {
     setState(prev => ({ ...prev, loading: true, error: null }));

--- a/lib/hooks/useLocalStorageCrud.ts
+++ b/lib/hooks/useLocalStorageCrud.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect } from 'react';
+import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { message } from 'antd';
 import type { ActionType } from '@ant-design/pro-components';
 import type { CrudParams, CrudOperation, CrudState, CrudTableActions } from './useCrudTable';
@@ -128,7 +128,10 @@ export const useLocalStorageCrud = <T extends Record<string, any>>(
     pageSize: config?.defaultPageSize || 10,
   });
 
-  const operations = createLocalStorageOperations<T>(storageKey, rowKey, initialData);
+  const operations = useMemo(
+    () => createLocalStorageOperations<T>(storageKey, rowKey, initialData),
+    [storageKey, rowKey, initialData]
+  );
 
   const refresh = useCallback(async () => {
     setState(prev => ({ ...prev, loading: true, error: null }));


### PR DESCRIPTION
Closes #2

> **Stacked on #9** — this branch is based on `fix/protable-request-operations`; merge that one first and this PR will retarget to `main` automatically.

## What

- Operations are now resolved inside a `useMemo` keyed on the actual strategy inputs (`operations` / `staticData` / `api` / `rowKey`) in `useCrudTable`, and on (`storageKey` / `rowKey` / `initialData`) in `useLocalStorageCrud`.
- Static id generation guards the empty-dataset case: `staticData: []` now hands out ids starting at 1 instead of `-Infinity`.

## Why

The operations factory ran on **every render**. The static strategy keeps its working dataset in the factory closure, so each re-render silently reset it to the original `staticData` — every create/update/delete was dropped (the demo only survived because `optimisticUpdates` kept a shadow copy in React state). The unstable reference also invalidated all dependent `useCallback`s on each render.

## Verification

- `tsc --p tsconfig.build.json --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
