### PR TITLE
[fix]: apply baseUrl exactly once in API getList

### DIFF
--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -120,14 +120,20 @@ const createApiOperations = <T>(config: UseCrudTableConfigApi<T>): CrudOperation
 
   return {
     getList: async (params: CrudParams) => {
-      const url = new URL(`${baseUrl}${defaultEndpoints.list}`, window.location.origin);
+      // Only build the endpoint path + query here; fetchWithConfig is the
+      // single place that applies baseUrl, otherwise relative baseUrls
+      // (e.g. '/api') end up in the request twice.
+      const search = new URLSearchParams();
       Object.entries(params).forEach(([key, value]) => {
         if (value !== undefined && value !== null) {
-          url.searchParams.append(key, String(value));
+          search.append(key, String(value));
         }
       });
-      
-      const response = await fetchWithConfig(url.pathname + url.search);
+
+      const queryString = search.toString();
+      const response = await fetchWithConfig(
+        queryString ? `${defaultEndpoints.list}?${queryString}` : defaultEndpoints.list
+      );
       return transform?.response ? transform.response(response) : response;
     },
     


### PR DESCRIPTION
Closes #3

> **Stacked on #10** — based on `fix/static-operations-stability`; merges in order #9 → #10 → this.

## What

`createApiOperations.getList` no longer prepends `baseUrl` itself. It builds only the endpoint path + query string (via `URLSearchParams`, skipping `undefined`/`null`), and `fetchWithConfig` remains the single place that applies `baseUrl`.

## Why

The old code built `new URL(baseUrl + endpoint, origin)` and then passed `url.pathname + url.search` into `fetchWithConfig`, which prefixes `baseUrl` **again**. With an absolute `baseUrl` the two steps happened to cancel out; with a relative one (`/api`) every list request went to `/api/api/list`.

## Verification

- `tsc --p tsconfig.build.json --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
