### PR TITLE
[refactor]: one CRUD engine - merge useLocalStorageCrud into useCrudTable

### DIFF
--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -2,6 +2,8 @@ import { useState, useCallback, useMemo, useRef } from 'react';
 import { message } from 'antd';
 import type { ActionType } from '@ant-design/pro-components';
 
+import { applyQuery } from '../utils/query';
+
 export type CrudOperation<T> = {
   getList: (params: CrudParams) => Promise<CrudResponse<T>>;
   create: (data: Partial<T>) => Promise<T>;
@@ -162,7 +164,7 @@ const createApiOperations = <T>(config: UseCrudTableConfigApi<T>): CrudOperation
 };
 
 // Static data operations
-const createStaticOperations = <T>(staticData: T[], keyField: keyof T): CrudOperation<T> => {
+const createStaticOperations = <T extends Record<string, any>>(staticData: T[], keyField: keyof T): CrudOperation<T> => {
   const data = [...staticData];
   // Math.max() over an empty spread is -Infinity, so guard the empty case
   let nextId = data.length > 0
@@ -170,40 +172,7 @@ const createStaticOperations = <T>(staticData: T[], keyField: keyof T): CrudOper
     : 1;
 
   return {
-    getList: async (params: CrudParams) => {
-      const { current = 1, pageSize = 10, sortBy, sortOrder, ...filters } = params;
-      
-      let filteredData = [...data];
-      
-      // Apply filters
-      Object.entries(filters).forEach(([key, value]) => {
-        if (value !== undefined && value !== null && value !== '') {
-          filteredData = filteredData.filter(item => 
-            String(item[key as keyof T]).toLowerCase().includes(String(value).toLowerCase())
-          );
-        }
-      });
-      
-      // Apply sorting
-      if (sortBy && sortOrder) {
-        filteredData.sort((a, b) => {
-          const aVal = a[sortBy as keyof T];
-          const bVal = b[sortBy as keyof T];
-          const comparison = aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
-          return sortOrder === 'ascend' ? comparison : -comparison;
-        });
-      }
-      
-      // Apply pagination
-      const start = (current - 1) * pageSize;
-      const paginatedData = filteredData.slice(start, start + pageSize);
-      
-      return {
-        data: paginatedData,
-        total: filteredData.length,
-        success: true,
-      };
-    },
+    getList: async (params: CrudParams) => applyQuery(data, params),
     
     create: async (newData: Partial<T>) => {
       const item = { 

--- a/lib/hooks/useLocalStorageCrud.ts
+++ b/lib/hooks/useLocalStorageCrud.ts
@@ -1,7 +1,8 @@
-import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
-import { message } from 'antd';
-import type { ActionType } from '@ant-design/pro-components';
-import type { CrudParams, CrudOperation, CrudState, CrudTableActions } from './useCrudTable';
+import { useEffect, useMemo } from 'react';
+
+import { useCrudTable } from './useCrudTable';
+import type { CrudOperation, CrudParams, CrudTableActions } from './useCrudTable';
+import { applyQuery } from '../utils/query';
 
 export type UseLocalStorageCrudConfig = {
   defaultPageSize?: number;
@@ -33,44 +34,8 @@ const createLocalStorageOperations = <T extends Record<string, any>>(
   initialData: T[] = []
 ): CrudOperation<T> => {
   return {
-    getList: async (params: CrudParams) => {
-      const { current = 1, pageSize = 10, sortBy, sortOrder, ...filters } = params;
-
-      let filteredData = getStoredData<T>(storageKey, initialData);
-
-      // Apply filters
-      Object.entries(filters).forEach(([key, value]) => {
-        if (value !== undefined && value !== null && value !== '' && key !== 'current' && key !== 'pageSize') {
-          filteredData = filteredData.filter(item => {
-            const itemValue = item[key as keyof T];
-            if (itemValue === undefined || itemValue === null) return false;
-            return String(itemValue).toLowerCase().includes(String(value).toLowerCase());
-          });
-        }
-      });
-
-      // Apply sorting
-      if (sortBy && sortOrder) {
-        filteredData.sort((a, b) => {
-          const aVal = a[sortBy as keyof T];
-          const bVal = b[sortBy as keyof T];
-          if (aVal === undefined || aVal === null) return 1;
-          if (bVal === undefined || bVal === null) return -1;
-          const comparison = aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
-          return sortOrder === 'ascend' ? comparison : -comparison;
-        });
-      }
-
-      // Apply pagination
-      const start = (current - 1) * pageSize;
-      const paginatedData = filteredData.slice(start, start + pageSize);
-
-      return {
-        data: paginatedData,
-        total: filteredData.length,
-        success: true,
-      };
-    },
+    getList: async (params: CrudParams) =>
+      applyQuery(getStoredData<T>(storageKey, initialData), params),
 
     create: async (newData: Partial<T>) => {
       const data = getStoredData<T>(storageKey, initialData);
@@ -112,163 +77,33 @@ const createLocalStorageOperations = <T extends Record<string, any>>(
   };
 };
 
+/**
+ * localStorage-backed CRUD hook. A thin wrapper that builds
+ * localStorage operations and delegates all state management to the
+ * shared useCrudTable engine.
+ */
 export const useLocalStorageCrud = <T extends Record<string, any>>(
   rowKey: keyof T,
   storageKey: string,
   initialData: T[] = [],
   config?: UseLocalStorageCrudConfig
 ): CrudTableActions<T> => {
-  const actionRef = useRef<ActionType>(null);
-  const [state, setState] = useState<CrudState<T>>({
-    loading: false,
-    error: null,
-    data: [],
-    total: 0,
-    current: 1,
-    pageSize: config?.defaultPageSize || 10,
-  });
-
   const operations = useMemo(
     () => createLocalStorageOperations<T>(storageKey, rowKey, initialData),
     [storageKey, rowKey, initialData]
   );
 
-  const refresh = useCallback(async () => {
-    setState(prev => ({ ...prev, loading: true, error: null }));
+  const actions = useCrudTable<T>(rowKey, { ...config, operations });
 
-    try {
-      const params: CrudParams = {
-        current: state.current,
-        pageSize: state.pageSize,
-      };
-
-      const response = await operations.getList(params);
-
-      setState(prev => ({
-        ...prev,
-        data: response.data,
-        total: response.total,
-        loading: false,
-      }));
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to fetch data';
-      setState(prev => ({ ...prev, loading: false, error: errorMessage }));
-      config?.onError?.('fetch', error);
-      message.error(errorMessage);
-    }
-  }, [state.current, state.pageSize, operations, config]);
-
+  // Standalone consumers read state.data directly, so load once on mount
+  // (mount-only on purpose: refresh's identity changes with state).
+  const { refresh } = actions;
   useEffect(() => {
     refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const create = useCallback(async (data: Partial<T>): Promise<T | null> => {
-    try {
-      setState(prev => ({ ...prev, loading: true }));
-      const result = await operations.create(data);
-
-      if (config?.optimisticUpdates) {
-        setState(prev => ({
-          ...prev,
-          data: [...prev.data, result],
-          total: prev.total + 1,
-          loading: false,
-        }));
-      } else {
-        await refresh();
-      }
-
-      config?.onSuccess?.('create', result);
-      message.success('Created successfully');
-      actionRef.current?.reload();
-      return result;
-    } catch (error) {
-      setState(prev => ({ ...prev, loading: false }));
-      const errorMessage = error instanceof Error ? error.message : 'Create failed';
-      config?.onError?.('create', error);
-      message.error(errorMessage);
-      return null;
-    }
-  }, [operations, config, refresh]);
-
-  const update = useCallback(async (id: any, data: Partial<T>): Promise<T | null> => {
-    try {
-      setState(prev => ({ ...prev, loading: true }));
-      const result = await operations.update(id, data);
-
-      if (config?.optimisticUpdates) {
-        setState(prev => ({
-          ...prev,
-          data: prev.data.map(item =>
-            item[rowKey] === id ? { ...item, ...result } : item
-          ),
-          loading: false,
-        }));
-      } else {
-        await refresh();
-      }
-
-      config?.onSuccess?.('update', result);
-      message.success('Updated successfully');
-      actionRef.current?.reload();
-      return result;
-    } catch (error) {
-      setState(prev => ({ ...prev, loading: false }));
-      const errorMessage = error instanceof Error ? error.message : 'Update failed';
-      config?.onError?.('update', error);
-      message.error(errorMessage);
-      return null;
-    }
-  }, [operations, config, rowKey, refresh]);
-
-  const deleteItem = useCallback(async (id: any): Promise<boolean> => {
-    try {
-      setState(prev => ({ ...prev, loading: true }));
-      await operations.delete(id);
-
-      if (config?.optimisticUpdates) {
-        setState(prev => ({
-          ...prev,
-          data: prev.data.filter(item => item[rowKey] !== id),
-          total: prev.total - 1,
-          loading: false,
-        }));
-      } else {
-        await refresh();
-      }
-
-      config?.onSuccess?.('delete', id);
-      message.success('Deleted successfully');
-      actionRef.current?.reload();
-      return true;
-    } catch (error) {
-      setState(prev => ({ ...prev, loading: false }));
-      const errorMessage = error instanceof Error ? error.message : 'Delete failed';
-      config?.onError?.('delete', error);
-      message.error(errorMessage);
-      return false;
-    }
-  }, [operations, config, rowKey, refresh]);
-
-  const setPageSize = useCallback((size: number) => {
-    setState(prev => ({ ...prev, pageSize: size, current: 1 }));
-  }, []);
-
-  const setCurrentPage = useCallback((page: number) => {
-    setState(prev => ({ ...prev, current: page }));
-  }, []);
-
-  return {
-    refresh,
-    create,
-    update,
-    delete: deleteItem,
-    operations,
-    setPageSize,
-    setCurrentPage,
-    state,
-    actionRef,
-  };
+  return actions;
 };
 
 export default useLocalStorageCrud;

--- a/lib/utils/query.ts
+++ b/lib/utils/query.ts
@@ -1,0 +1,46 @@
+import type { CrudParams, CrudResponse } from '../hooks/useCrudTable';
+
+/**
+ * Shared in-memory query pipeline: filter, then sort, then paginate.
+ *
+ * Used by every strategy that queries a local dataset (static data,
+ * localStorage) so the behaviour stays identical across them.
+ *
+ * - Filters are case-insensitive substring matches; params that are
+ *   undefined/null/'' are ignored, and rows whose value is missing never
+ *   match.
+ * - Sorting puts missing values last regardless of direction.
+ */
+export const applyQuery = <T extends Record<string, any>>(
+  data: T[],
+  params: CrudParams
+): CrudResponse<T> => {
+  const { current = 1, pageSize = 10, sortBy, sortOrder, ...filters } = params;
+
+  let result = data.filter((item) =>
+    Object.entries(filters).every(([key, value]) => {
+      if (value === undefined || value === null || value === '') return true;
+      const itemValue = item[key as keyof T];
+      if (itemValue === undefined || itemValue === null) return false;
+      return String(itemValue).toLowerCase().includes(String(value).toLowerCase());
+    })
+  );
+
+  if (sortBy && sortOrder) {
+    result = [...result].sort((a, b) => {
+      const aVal = a[sortBy as keyof T];
+      const bVal = b[sortBy as keyof T];
+      if (aVal === undefined || aVal === null) return 1;
+      if (bVal === undefined || bVal === null) return -1;
+      const comparison = aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+      return sortOrder === 'ascend' ? comparison : -comparison;
+    });
+  }
+
+  const start = (current - 1) * pageSize;
+  return {
+    data: result.slice(start, start + pageSize),
+    total: result.length,
+    success: true,
+  };
+};


### PR DESCRIPTION
Closes #4

> **Stacked on #11** — merge order: #9 → #10 → #11 → this.

## What

1. **New `lib/utils/query.ts`** — `applyQuery(data, params)`, the single filter → sort → paginate implementation for every local-dataset strategy. The static strategy's `getList` is now a one-liner.
2. **`useLocalStorageCrud` rewritten as a thin wrapper** (270 → ~110 lines, net −183): it builds a localStorage-backed `CrudOperation<T>` factory and delegates all state management (loading/error/messages/optimistic updates) to `useCrudTable` via the custom-operations strategy. A mount-only `refresh()` is kept so standalone consumers that read `state.data` directly keep working.

Public API is unchanged: same hook signature, same returned `CrudTableActions<T>`, same `UseLocalStorageCrudConfig`.

## Why

The localStorage hook re-implemented the entire state engine from `useCrudTable`, and the in-memory query pipeline existed in three slightly different copies. Every bug had to be fixed in multiple places (the id-generation and stale-closure bugs from #2 existed in both hooks in different forms). One engine, one query pipeline, one place to fix things.

Unifying the query pipeline also picks up the stricter copy's edge-case behavior everywhere: missing values no longer match filters via the literal string `"undefined"`, and missing values sort last in either direction.

## Verification

- `tsc --p tsconfig.build.json --noEmit` and `pnpm build:lib` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
