### PR TITLE
[feature]: field-type registry + 14 new field types

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,12 +538,39 @@ const RealtimeTable = () => {
 |------|------|-------------|
 | `dataIndex` | `keyof T` | Field key in your data |
 | `title` | `string` | Column header text |
-| `fieldType` | `FieldType` | `"string" \| "number" \| "boolean" \| "date" \| "enum" \| "custom"` |
+| `fieldType` | `FieldType` | See the field type table below (default: `"string"`) |
 | `fieldEditable?` | `boolean` | Whether field can be edited (default: true) |
 | `searchable?` | `boolean` | Whether field appears in search (default: true) |
 | `enumOptions?` | `Record<string, {text: string, color?: string}>` | Options for enum fields |
 | `customRender?` | `(value, record) => ReactNode` | Custom display renderer |
 | `formConfig?` | `FormConfig` | Form field configuration |
+
+### Field Types
+
+| `fieldType` | Stored as | Table cell | Form control |
+|-------------|-----------|------------|--------------|
+| `string` (default) | `string` | text | `Input` |
+| `textarea` | `string` | ellipsised text | `Input.TextArea` |
+| `email` | `string` | `mailto:` link (validated) | `Input` |
+| `url` | `string` | link (validated) | `Input` |
+| `password` | `string` | masked, excluded from search | `Input.Password` |
+| `number` | `number` | localized number | `InputNumber` |
+| `money` | `number` | currency (via ProTable intl) | `InputNumber` |
+| `percent` | `number` | percentage | `InputNumber` 0–100 |
+| `rating` | `number` | stars | `Rate` |
+| `progress` | `number` | progress bar | `InputNumber` 0–100 |
+| `date` | ISO string | `YYYY-MM-DD HH:mm` | `DatePicker` |
+| `time` | `HH:mm:ss` string | time | `TimePicker` |
+| `dateRange` | `[startISO, endISO]` | `start ~ end` | `RangePicker` |
+| `boolean` | `boolean` | Yes/No tag | `Switch` |
+| `enum` | `string` | colored tag | `Select` |
+| `tags` | `string[]` | tag list | `Select mode="tags"` |
+| `image` | URL string | 48px preview | `Input` (URL, validated) |
+| `color` | hex string | swatch + code | `ColorPicker` |
+| `json` | object | inline code | validated `Input.TextArea` |
+| `custom` | anything | `customRender` | `formConfig.component` |
+
+Every field type is one entry in the exported `fieldRegistry` (`lib/fields/registry.tsx`), declaring its cell render, form control, implied validation rules and record↔form value conversion in one place.
 
 ### FormConfig
 

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -1,17 +1,15 @@
 import { PlusOutlined, EllipsisOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-components';
 import { ProTable, ProConfigProvider, enUSIntl } from '@ant-design/pro-components';
-import { Button, Dropdown, Tag, message, Modal, Form, Input, InputNumber, Select, Switch, DatePicker } from 'antd';
+import { Button, Dropdown, message, Modal, Form } from 'antd';
 import { useState } from 'react';
 import type { SortOrder } from 'antd/es/table/interface';
-import { format, parseISO, formatISO } from 'date-fns';
-import dayjs from 'dayjs';
 
 import './CrudTable.css';
 import { useCrudTable, type UseCrudTableConfig, type CrudTableActions } from './hooks/useCrudTable';
+import { getFieldDefinition, type FieldType } from './fields/registry';
 
 type DataType = Record<string, any>;
-type FieldType = 'string' | 'number' | 'date' | 'boolean' | 'enum' | 'custom';
 
 interface CrudColumn<T extends DataType> extends ProColumns<T> {
   fieldType?: FieldType;
@@ -57,7 +55,7 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [form] = Form.useForm();
 
-  // Enhanced columns with better type handling
+  // Enhanced columns: base props + whatever the field-type registry adds
   const enhancedColumns: ProColumns<T>[] = columns.map((col) => {
     const baseColumn: ProColumns<T> = {
       ...col,
@@ -66,63 +64,11 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
       search: col.searchable !== false, // Default to searchable
     };
 
-    switch (col.fieldType) {
-      case 'date':
-        return {
-          ...baseColumn,
-          valueType: 'dateTime',
-          render: (_, record) => {
-            const value = record[col.dataIndex as string];
-            if (!value) return '-';
-            try {
-              return (
-                <span>
-                  {format(parseISO(value), 'yyyy-MM-dd HH:mm')}
-                </span>
-              );
-            } catch {
-              return <span>{value}</span>;
-            }
-          },
-        };
-      case 'enum':
-        return {
-          ...baseColumn,
-          valueType: 'select',
-          valueEnum: col.enumOptions,
-          render: (_, record) => {
-            const value = record[col.dataIndex as string];
-            const option = col.enumOptions?.[value];
-            return option ? <Tag color={option.color}>{option.text}</Tag> : value;
-          },
-        };
-      case 'number':
-        return {
-          ...baseColumn,
-          valueType: 'digit',
-          render: (_, record) => {
-            const value = record[col.dataIndex as string];
-            return typeof value === 'number' ? value.toLocaleString() : value;
-          },
-        };
-      case 'boolean':
-        return {
-          ...baseColumn,
-          valueType: 'switch',
-          render: (_, record) => (
-            <Tag color={record[col.dataIndex as string] ? 'green' : 'red'}>
-              {record[col.dataIndex as string] ? 'Yes' : 'No'}
-            </Tag>
-          ),
-        };
-      case 'custom':
-        return {
-          ...baseColumn,
-          render: (_, record) => col.customRender?.(record[col.dataIndex as string], record),
-        };
-      default:
-        return baseColumn;
-    }
+    const definition = getFieldDefinition(col.fieldType);
+    return {
+      ...baseColumn,
+      ...(definition.column?.(col) as Partial<ProColumns<T>> | undefined),
+    };
   });
 
   // Add actions column
@@ -197,15 +143,15 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
   const openModal = (record?: Partial<T>) => {
     setCurrentRecord(record || null);
     if (record) {
-      const values = { ...record };
+      const values: Record<string, any> = { ...record };
       columns.forEach((col) => {
         const field = col.dataIndex as string;
-        if (col.fieldType === 'date' && values[field]) {
+        const toFormValue = getFieldDefinition(col.fieldType).toFormValue;
+        if (toFormValue && values[field] !== undefined) {
           try {
-            // @ts-expect-error partial data type date handling
-            values[field] = dayjs(values[field]);
+            values[field] = toFormValue(values[field]);
           } catch {
-            // Keep original value if parsing fails
+            // Keep original value if conversion fails
           }
         }
       });
@@ -221,18 +167,20 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
       const values = await form.validateFields();
       const transformedValues = { ...values };
 
-      // Handle transformations
+      // Handle transformations: registry serialization first, then the
+      // column's own transform on top
       columns.forEach((col) => {
         const field = col.dataIndex as string;
-        if (col.fieldType === 'date' && values[field]) {
+        const fromFormValue = getFieldDefinition(col.fieldType).fromFormValue;
+        if (fromFormValue && values[field] !== undefined) {
           try {
-            transformedValues[field] = formatISO(values[field]);
+            transformedValues[field] = fromFormValue(values[field]);
           } catch {
-            // Keep original value if formatting fails
+            // Keep original value if serialization fails
           }
         }
         if (col.formConfig?.transform) {
-          transformedValues[field] = col.formConfig.transform(values[field]);
+          transformedValues[field] = col.formConfig.transform(transformedValues[field]);
         }
       });
 
@@ -368,90 +316,29 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
             const name = col.dataIndex as string;
             const label = col.title as string;
             const fieldDisabled = !(col.fieldEditable ?? true);
-            const rules = col.formConfig?.rules || (col.formConfig?.required ? [
+            const definition = getFieldDefinition(col.fieldType);
+
+            const userRules = col.formConfig?.rules || (col.formConfig?.required ? [
               { required: true, message: `${label} is required` }
             ] : []);
+            const rules = [...(definition.rules?.(col) ?? []), ...userRules];
 
             // Custom component override
-            if (col.formConfig?.component) {
-              return (
-                <Form.Item
-                  key={name}
-                  name={name}
-                  label={label}
-                  rules={rules}
-                >
-                  {col.formConfig.component}
-                </Form.Item>
-              );
-            }
+            const control = col.formConfig?.component
+              ?? definition.formControl(col, fieldDisabled);
+            if (!control) return null;
 
-            switch (col.fieldType) {
-              case 'string':
-                return (
-                  <Form.Item
-                    key={name}
-                    name={name}
-                    label={label}
-                    rules={rules}
-                  >
-                    <Input disabled={fieldDisabled} />
-                  </Form.Item>
-                );
-              case 'number':
-                return (
-                  <Form.Item
-                    key={name}
-                    name={name}
-                    label={label}
-                    rules={rules}
-                  >
-                    <InputNumber style={{ width: '100%' }} disabled={fieldDisabled} />
-                  </Form.Item>
-                );
-              case 'date':
-                return (
-                  <Form.Item
-                    key={name}
-                    name={name}
-                    label={label}
-                    rules={rules}
-                  >
-                    <DatePicker style={{ width: '100%' }} showTime disabled={fieldDisabled} />
-                  </Form.Item>
-                );
-              case 'boolean':
-                return (
-                  <Form.Item
-                    key={name}
-                    name={name}
-                    label={label}
-                    valuePropName="checked"
-                  >
-                    <Switch disabled={fieldDisabled} />
-                  </Form.Item>
-                );
-              case 'enum':
-                return (
-                  <Form.Item
-                    key={name}
-                    name={name}
-                    label={label}
-                    rules={rules}
-                  >
-                    <Select 
-                      disabled={fieldDisabled}
-                      placeholder={`Select ${label.toLowerCase()}`}
-                      options={Object.entries(col.enumOptions || {}).map(([value, option]) => ({
-                        label: option.text,
-                        value,
-                      }))} 
-                    />
-                  </Form.Item>
-                );
-              default:
-                return null;
-            }
+            return (
+              <Form.Item
+                key={name}
+                name={name}
+                label={label}
+                rules={rules}
+                valuePropName={definition.valuePropName}
+              >
+                {control}
+              </Form.Item>
+            );
           })}
         </Form>
       </Modal>

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -1,4 +1,4 @@
-import { Input, InputNumber, Select, Switch, DatePicker, Tag } from 'antd';
+import { Input, InputNumber, Select, Switch, DatePicker, Tag, Rate, Progress } from 'antd';
 import type { ProColumns } from '@ant-design/pro-components';
 import dayjs from 'dayjs';
 
@@ -13,7 +13,11 @@ export type FieldType =
   | 'textarea'
   | 'email'
   | 'url'
-  | 'password';
+  | 'password'
+  | 'money'
+  | 'percent'
+  | 'rating'
+  | 'progress';
 
 /** The slice of a CrudColumn a field-type definition may look at. */
 export interface FieldColumn {
@@ -171,6 +175,49 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
       render: (_, record) => (cellValue(col, record) ? '••••••••' : '-'),
     }),
     formControl: (_col, disabled) => <Input.Password disabled={disabled} />,
+  },
+
+  money: {
+    // ProTable's money valueType formats via the active intl (enUSIntl here)
+    column: () => ({ valueType: 'money' }),
+    formControl: (_col, disabled) => (
+      <InputNumber style={{ width: '100%' }} precision={2} min={0} disabled={disabled} />
+    ),
+  },
+
+  percent: {
+    column: () => ({ valueType: 'percent' }),
+    formControl: (_col, disabled) => (
+      <InputNumber
+        style={{ width: '100%' }}
+        min={0}
+        max={100}
+        addonAfter="%"
+        disabled={disabled}
+      />
+    ),
+  },
+
+  rating: {
+    column: (col) => ({
+      search: false,
+      render: (_, record) => (
+        <Rate disabled allowHalf value={Number(cellValue(col, record)) || 0} />
+      ),
+    }),
+    formControl: (_col, disabled) => <Rate allowHalf disabled={disabled} />,
+  },
+
+  progress: {
+    column: (col) => ({
+      search: false,
+      render: (_, record) => (
+        <Progress percent={Number(cellValue(col, record)) || 0} size="small" />
+      ),
+    }),
+    formControl: (_col, disabled) => (
+      <InputNumber style={{ width: '100%' }} min={0} max={100} disabled={disabled} />
+    ),
   },
 };
 

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -1,4 +1,4 @@
-import { Input, InputNumber, Select, Switch, DatePicker, TimePicker, Tag, Rate, Progress } from 'antd';
+import { Input, InputNumber, Select, Switch, DatePicker, TimePicker, Tag, Rate, Progress, Image, ColorPicker, Typography } from 'antd';
 import type { ProColumns } from '@ant-design/pro-components';
 import dayjs from 'dayjs';
 
@@ -19,7 +19,11 @@ export type FieldType =
   | 'rating'
   | 'progress'
   | 'time'
-  | 'dateRange';
+  | 'dateRange'
+  | 'tags'
+  | 'image'
+  | 'color'
+  | 'json';
 
 /** The slice of a CrudColumn a field-type definition may look at. */
 export interface FieldColumn {
@@ -256,6 +260,104 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
       Array.isArray(value)
         ? value.map((v) => (dayjs.isDayjs(v) ? v.toISOString() : v))
         : value,
+  },
+
+  // Stored as string[]
+  tags: {
+    column: (col) => ({
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        if (!Array.isArray(value) || value.length === 0) return '-';
+        return (
+          <>
+            {value.map((tag: string) => (
+              <Tag key={tag}>{tag}</Tag>
+            ))}
+          </>
+        );
+      },
+    }),
+    formControl: (_col, disabled) => (
+      <Select mode="tags" open={false} suffixIcon={null} disabled={disabled} placeholder="Type and press enter" />
+    ),
+  },
+
+  // Stored as an image URL
+  image: {
+    column: (col) => ({
+      search: false,
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        return value ? <Image src={value} width={48} height={48} style={{ objectFit: 'cover' }} /> : '-';
+      },
+    }),
+    formControl: (_col, disabled) => (
+      <Input placeholder="https://..." disabled={disabled} />
+    ),
+    rules: () => [{ type: 'url', message: 'Please enter a valid image URL' }],
+  },
+
+  // Stored as a hex string
+  color: {
+    column: (col) => ({
+      search: false,
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        if (!value) return '-';
+        return (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 14,
+                height: 14,
+                borderRadius: 3,
+                border: '1px solid rgba(0,0,0,0.15)',
+                backgroundColor: value,
+              }}
+            />
+            {value}
+          </span>
+        );
+      },
+    }),
+    formControl: (_col, disabled) => <ColorPicker showText disabled={disabled} />,
+    fromFormValue: (value) =>
+      value && typeof value === 'object' && 'toHexString' in value
+        ? (value as { toHexString: () => string }).toHexString()
+        : value,
+  },
+
+  // Stored as a plain object/array
+  json: {
+    column: (col) => ({
+      search: false,
+      ellipsis: true,
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        if (value === undefined || value === null) return '-';
+        return <Typography.Text code>{JSON.stringify(value)}</Typography.Text>;
+      },
+    }),
+    formControl: (_col, disabled) => (
+      <Input.TextArea rows={4} style={{ fontFamily: 'monospace' }} disabled={disabled} />
+    ),
+    toFormValue: (value) =>
+      typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+    fromFormValue: (value) => (typeof value === 'string' && value.trim() !== '' ? JSON.parse(value) : value),
+    rules: () => [
+      {
+        validator: async (_rule: unknown, value: unknown) => {
+          if (value === undefined || value === null || value === '') return;
+          if (typeof value !== 'string') return;
+          try {
+            JSON.parse(value);
+          } catch {
+            throw new Error('Please enter valid JSON');
+          }
+        },
+      },
+    ],
   },
 };
 

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -1,4 +1,4 @@
-import { Input, InputNumber, Select, Switch, DatePicker, Tag, Rate, Progress } from 'antd';
+import { Input, InputNumber, Select, Switch, DatePicker, TimePicker, Tag, Rate, Progress } from 'antd';
 import type { ProColumns } from '@ant-design/pro-components';
 import dayjs from 'dayjs';
 
@@ -17,7 +17,9 @@ export type FieldType =
   | 'money'
   | 'percent'
   | 'rating'
-  | 'progress';
+  | 'progress'
+  | 'time'
+  | 'dateRange';
 
 /** The slice of a CrudColumn a field-type definition may look at. */
 export interface FieldColumn {
@@ -54,6 +56,8 @@ const cellValue = (col: FieldColumn, record: Record<string, any>) =>
   record[col.dataIndex as string];
 
 const DATE_TIME_DISPLAY = 'YYYY-MM-DD HH:mm';
+const DATE_DISPLAY = 'YYYY-MM-DD';
+const TIME_VALUE = 'HH:mm:ss';
 
 export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
   string: {
@@ -218,6 +222,40 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
     formControl: (_col, disabled) => (
       <InputNumber style={{ width: '100%' }} min={0} max={100} disabled={disabled} />
     ),
+  },
+
+  // Stored as an 'HH:mm:ss' string
+  time: {
+    column: () => ({ valueType: 'time' }),
+    formControl: (_col, disabled) => (
+      <TimePicker style={{ width: '100%' }} disabled={disabled} />
+    ),
+    toFormValue: (value) => (value ? dayjs(value, TIME_VALUE) : value),
+    fromFormValue: (value) =>
+      dayjs.isDayjs(value) ? value.format(TIME_VALUE) : value,
+  },
+
+  // Stored as a [startISO, endISO] tuple
+  dateRange: {
+    column: (col) => ({
+      valueType: 'dateRange',
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        if (!Array.isArray(value) || value.length !== 2) return '-';
+        const [start, end] = value.map((v) => dayjs(v));
+        if (!start.isValid() || !end.isValid()) return String(value);
+        return `${start.format(DATE_DISPLAY)} ~ ${end.format(DATE_DISPLAY)}`;
+      },
+    }),
+    formControl: (_col, disabled) => (
+      <DatePicker.RangePicker style={{ width: '100%' }} disabled={disabled} />
+    ),
+    toFormValue: (value) =>
+      Array.isArray(value) ? value.map((v) => (v ? dayjs(v) : v)) : value,
+    fromFormValue: (value) =>
+      Array.isArray(value)
+        ? value.map((v) => (dayjs.isDayjs(v) ? v.toISOString() : v))
+        : value,
   },
 };
 

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -9,7 +9,11 @@ export type FieldType =
   | 'date'
   | 'boolean'
   | 'enum'
-  | 'custom';
+  | 'custom'
+  | 'textarea'
+  | 'email'
+  | 'url'
+  | 'password';
 
 /** The slice of a CrudColumn a field-type definition may look at. */
 export interface FieldColumn {
@@ -125,6 +129,48 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
     // Custom columns bring their own control via formConfig.component
     // (handled before the registry lookup); otherwise they have no form field.
     formControl: () => null,
+  },
+
+  textarea: {
+    column: () => ({ valueType: 'textarea', ellipsis: true }),
+    formControl: (_col, disabled) => (
+      <Input.TextArea rows={3} disabled={disabled} />
+    ),
+  },
+
+  email: {
+    column: (col) => ({
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        return value ? <a href={`mailto:${value}`}>{value}</a> : '-';
+      },
+    }),
+    formControl: (_col, disabled) => <Input type="email" disabled={disabled} />,
+    rules: () => [{ type: 'email', message: 'Please enter a valid email' }],
+  },
+
+  url: {
+    column: (col) => ({
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        return value ? (
+          <a href={value} target="_blank" rel="noopener noreferrer">
+            {value}
+          </a>
+        ) : '-';
+      },
+    }),
+    formControl: (_col, disabled) => <Input disabled={disabled} />,
+    rules: () => [{ type: 'url', message: 'Please enter a valid URL' }],
+  },
+
+  password: {
+    // Never show the value in the table, and keep it out of search by default
+    column: (col) => ({
+      search: false,
+      render: (_, record) => (cellValue(col, record) ? '••••••••' : '-'),
+    }),
+    formControl: (_col, disabled) => <Input.Password disabled={disabled} />,
   },
 };
 

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -1,0 +1,133 @@
+import { Input, InputNumber, Select, Switch, DatePicker, Tag } from 'antd';
+import type { ProColumns } from '@ant-design/pro-components';
+import dayjs from 'dayjs';
+
+/** Every column type CrudTable understands. */
+export type FieldType =
+  | 'string'
+  | 'number'
+  | 'date'
+  | 'boolean'
+  | 'enum'
+  | 'custom';
+
+/** The slice of a CrudColumn a field-type definition may look at. */
+export interface FieldColumn {
+  dataIndex?: unknown;
+  /** ProColumns allows ReactNode or a render function here, so stay loose. */
+  title?: unknown;
+  fieldType?: FieldType;
+  enumOptions?: Record<string, { text: string; [key: string]: any }>;
+  customRender?: (value: any, record: any) => React.ReactNode;
+}
+
+/**
+ * A self-contained description of one field type: how it renders in the
+ * table, which control edits it in the modal form, and how values are
+ * converted between record shape and form shape. Adding a new column
+ * type to CrudTable means adding exactly one entry here.
+ */
+export interface FieldTypeDefinition {
+  /** Extra ProColumns props merged over the base column (valueType, render, ...). */
+  column?: (col: FieldColumn) => Partial<ProColumns<any>>;
+  /** The antd control used in the create/edit modal. Return null for "no form field". */
+  formControl: (col: FieldColumn, disabled: boolean) => React.ReactNode | null;
+  /** Convert a record value into what the form control expects. */
+  toFormValue?: (value: any) => any;
+  /** Convert the submitted form value back into the record shape. */
+  fromFormValue?: (value: any) => any;
+  /** Validation rules implied by the type itself (merged before user rules). */
+  rules?: (col: FieldColumn) => any[];
+  /** Form.Item valuePropName override (e.g. 'checked' for Switch). */
+  valuePropName?: string;
+}
+
+const cellValue = (col: FieldColumn, record: Record<string, any>) =>
+  record[col.dataIndex as string];
+
+const DATE_TIME_DISPLAY = 'YYYY-MM-DD HH:mm';
+
+export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
+  string: {
+    formControl: (_col, disabled) => <Input disabled={disabled} />,
+  },
+
+  number: {
+    column: (col) => ({
+      valueType: 'digit',
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        return typeof value === 'number' ? value.toLocaleString() : value;
+      },
+    }),
+    formControl: (_col, disabled) => (
+      <InputNumber style={{ width: '100%' }} disabled={disabled} />
+    ),
+  },
+
+  date: {
+    column: (col) => ({
+      valueType: 'dateTime',
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        if (!value) return '-';
+        const parsed = dayjs(value);
+        return <span>{parsed.isValid() ? parsed.format(DATE_TIME_DISPLAY) : String(value)}</span>;
+      },
+    }),
+    formControl: (_col, disabled) => (
+      <DatePicker style={{ width: '100%' }} showTime disabled={disabled} />
+    ),
+    toFormValue: (value) => (value ? dayjs(value) : value),
+    fromFormValue: (value) =>
+      dayjs.isDayjs(value) ? value.toISOString() : value,
+  },
+
+  boolean: {
+    column: (col) => ({
+      valueType: 'switch',
+      render: (_, record) => (
+        <Tag color={cellValue(col, record) ? 'green' : 'red'}>
+          {cellValue(col, record) ? 'Yes' : 'No'}
+        </Tag>
+      ),
+    }),
+    formControl: (_col, disabled) => <Switch disabled={disabled} />,
+    valuePropName: 'checked',
+  },
+
+  enum: {
+    column: (col) => ({
+      valueType: 'select',
+      valueEnum: col.enumOptions,
+      render: (_, record) => {
+        const value = cellValue(col, record);
+        const option = col.enumOptions?.[value];
+        return option ? <Tag color={option.color}>{option.text}</Tag> : value;
+      },
+    }),
+    formControl: (col, disabled) => (
+      <Select
+        disabled={disabled}
+        placeholder={`Select ${String(col.title ?? '').toLowerCase()}`}
+        options={Object.entries(col.enumOptions || {}).map(([value, option]) => ({
+          label: option.text,
+          value,
+        }))}
+      />
+    ),
+  },
+
+  custom: {
+    column: (col) => ({
+      render: (_, record) => col.customRender?.(cellValue(col, record), record),
+    }),
+    // Custom columns bring their own control via formConfig.component
+    // (handled before the registry lookup); otherwise they have no form field.
+    formControl: () => null,
+  },
+};
+
+/** Look up a field type, falling back to `string` so every column gets a form control. */
+export const getFieldDefinition = (fieldType?: FieldType): FieldTypeDefinition =>
+  fieldRegistry[fieldType ?? 'string'] ?? fieldRegistry.string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,10 @@ export { useLocalStorageCrud } from './hooks/useLocalStorageCrud';
 // Utils
 export { exportData, exportToCSV, exportToJSON, exportToXLSX, exportAllData } from './utils/exportData';
 
+// Field-type registry
+export { fieldRegistry, getFieldDefinition } from './fields/registry';
+export type { FieldType, FieldTypeDefinition, FieldColumn } from './fields/registry';
+
 // Types
 export type { CrudTableConfig, CrudColumn, DataType } from './CrudTable';
 export type {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import LocalStorageExample from './example/LocalStorageExample';
 import ApiBasedExample from './example/ApiBasedExample';
 import StaticDataExample from './example/StaticDataExample';
 import CustomOperationsExample from './example/CustomOperationsExample';
+import FieldTypesShowcase from './example/FieldTypesShowcase';
 
 const App = () => (
   <ConfigProvider locale={enUS}>
@@ -21,12 +22,13 @@ const App = () => (
       <StaticDataExample />
       <ApiBasedExample />
       <CustomOperationsExample />
+      <FieldTypesShowcase />
 
       <div style={{ marginTop: '2rem', padding: '1rem', background: '#f5f5f5', borderRadius: '8px' }}>
         <h3>Features</h3>
         <ul>
           <li><strong>Multiple Data Sources:</strong> Static data, REST API, localStorage, IndexedDB, GraphQL</li>
-          <li><strong>Field Types:</strong> String, Number, Date, Boolean, Enum, Custom</li>
+          <li><strong>Field Types:</strong> String, Textarea, Email, URL, Password, Number, Money, Percent, Rating, Progress, Date, Time, DateRange, Boolean, Enum, Tags, Image, Color, JSON, Custom</li>
           <li><strong>Operations:</strong> Create, Read, Update, Delete with validation</li>
           <li><strong>Export:</strong> CSV, JSON, XLSX support</li>
           <li><strong>Bulk Operations:</strong> Multi-select and batch delete</li>

--- a/src/example/FieldTypesShowcase.tsx
+++ b/src/example/FieldTypesShowcase.tsx
@@ -1,0 +1,97 @@
+import './../App.css';
+import CrudTableLazy from '../../lib/CrudTableLazy';
+import type { CrudColumn } from '../../lib/CrudTable';
+
+interface Product {
+  id: number;
+  name: string;
+  description: string;
+  homepage: string;
+  contactEmail: string;
+  price: number;
+  discount: number;
+  rating: number;
+  completion: number;
+  launchTime: string;
+  availability: [string, string];
+  tags: string[];
+  thumbnail: string;
+  themeColor: string;
+  metadata: Record<string, unknown>;
+}
+
+const mockProducts: Product[] = [
+  {
+    id: 1,
+    name: 'Aurora Desk Lamp',
+    description: 'A dimmable desk lamp with a warm-to-cool spectrum, designed for late night work sessions.',
+    homepage: 'https://example.com/aurora',
+    contactEmail: 'aurora@example.com',
+    price: 89.99,
+    discount: 15,
+    rating: 4.5,
+    completion: 80,
+    launchTime: '09:30:00',
+    availability: ['2026-01-01T00:00:00.000Z', '2026-06-30T00:00:00.000Z'],
+    tags: ['lighting', 'desk', 'smart-home'],
+    thumbnail: 'https://picsum.photos/seed/aurora/96',
+    themeColor: '#faad14',
+    metadata: { sku: 'AUR-001', warehouse: 'east' },
+  },
+  {
+    id: 2,
+    name: 'Borealis Keyboard',
+    description: 'Low-profile mechanical keyboard with hot-swappable switches and per-key RGB.',
+    homepage: 'https://example.com/borealis',
+    contactEmail: 'borealis@example.com',
+    price: 149.0,
+    discount: 0,
+    rating: 5,
+    completion: 100,
+    launchTime: '14:00:00',
+    availability: ['2026-03-15T00:00:00.000Z', '2026-12-31T00:00:00.000Z'],
+    tags: ['keyboard', 'mechanical'],
+    thumbnail: 'https://picsum.photos/seed/borealis/96',
+    themeColor: '#1677ff',
+    metadata: { sku: 'BOR-002', warehouse: 'west' },
+  },
+];
+
+const productColumns: CrudColumn<Product>[] = [
+  { dataIndex: 'name', title: 'Name', fieldType: 'string', formConfig: { required: true } },
+  { dataIndex: 'description', title: 'Description', fieldType: 'textarea', searchable: false },
+  { dataIndex: 'homepage', title: 'Homepage', fieldType: 'url', searchable: false },
+  { dataIndex: 'contactEmail', title: 'Contact', fieldType: 'email' },
+  { dataIndex: 'price', title: 'Price', fieldType: 'money' },
+  { dataIndex: 'discount', title: 'Discount', fieldType: 'percent', searchable: false },
+  { dataIndex: 'rating', title: 'Rating', fieldType: 'rating' },
+  { dataIndex: 'completion', title: 'Completion', fieldType: 'progress' },
+  { dataIndex: 'launchTime', title: 'Launch Time', fieldType: 'time', searchable: false },
+  { dataIndex: 'availability', title: 'Availability', fieldType: 'dateRange', searchable: false },
+  { dataIndex: 'tags', title: 'Tags', fieldType: 'tags', searchable: false },
+  { dataIndex: 'thumbnail', title: 'Thumbnail', fieldType: 'image' },
+  { dataIndex: 'themeColor', title: 'Theme', fieldType: 'color' },
+  { dataIndex: 'metadata', title: 'Metadata', fieldType: 'json' },
+];
+
+const FieldTypesShowcase = () => (
+  <div style={{ marginBottom: '2rem', border: '1px solid #1677ff', padding: '1rem', borderRadius: '8px' }}>
+    <h2>Example 5: Field Type Showcase</h2>
+    <p style={{ color: '#666', marginBottom: '1rem' }}>
+      Every extended field type in one table: textarea, url, email, money, percent,
+      rating, progress, time, dateRange, tags, image, color and json.
+    </p>
+    <CrudTableLazy<Product>
+      title="Product Catalog (All Field Types)"
+      rowKey="id"
+      defaultPageSize={5}
+      hookConfig={{
+        staticData: mockProducts,
+        optimisticUpdates: true,
+      }}
+      columns={productColumns}
+    />
+  </div>
+);
+
+export default FieldTypesShowcase;


### PR DESCRIPTION
Closes #5

> **Stacked on #12** — merge order: #9 → #10 → #11 → #12 → this.

## What

**1. Field-type registry** (`lib/fields/registry.tsx`) — cell rendering and modal form controls used to live in two long `switch` statements inside `CrudTable.tsx`. Each field type is now one self-contained `FieldTypeDefinition` declaring:

- `column(col)` — extra ProColumns props (valueType, render, …)
- `formControl(col, disabled)` — the antd control for the create/edit modal
- `toFormValue` / `fromFormValue` — record ↔ form conversions (dates → dayjs, json → text, …)
- `rules(col)` — validation the type itself implies (email/url/json)
- `valuePropName` — e.g. `checked` for Switch

`CrudTable.tsx` just looks definitions up. Adding a type = adding one registry entry.

**2. 14 new field types** on top of the original 6:

| group | types |
|---|---|
| text | `textarea`, `email`, `url`, `password` |
| numeric | `money`, `percent`, `rating`, `progress` |
| temporal | `time`, `dateRange` |
| rich | `tags`, `image`, `color`, `json` |

**3. Deliberate behavior fixes**

- Columns without a `fieldType` now default to `string` (previously they rendered **no form control at all**).
- `formConfig.transform` now composes on top of the type's serialization instead of racing it on the raw form value.
- `password` is masked in the table and excluded from search by default.

**4. Demo + docs** — new "Field Type Showcase" example exercising all types; README gains a full field-type table; the registry and its types are exported from the barrel.

Note: the registry renders dates with `dayjs` (already a peer dep via antd); this clears the way for dropping `date-fns` entirely in #7.

## Verification

- `tsc` (lib + app configs) and `pnpm build:lib` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
