### PR TITLE
[feature]: working toolbar export + valid Excel output

### DIFF
--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -2,12 +2,13 @@ import { PlusOutlined, EllipsisOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-components';
 import { ProTable, ProConfigProvider, enUSIntl } from '@ant-design/pro-components';
 import { Button, Dropdown, message, Modal, Form } from 'antd';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { SortOrder } from 'antd/es/table/interface';
 
 import './CrudTable.css';
 import { useCrudTable, type UseCrudTableConfig, type CrudTableActions } from './hooks/useCrudTable';
 import { getFieldDefinition, type FieldType } from './fields/registry';
+import { exportData, type ExportFormat } from './utils/exportData';
 
 type DataType = Record<string, any>;
 
@@ -42,7 +43,7 @@ interface CrudTableConfig<T extends DataType> {
 }
 
 const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
-  const { columns, rowKey, title, defaultPageSize = 10, hookConfig, enableBulkOperations = false, customActions } = config;
+  const { columns, rowKey, title, defaultPageSize = 10, hookConfig, enableBulkOperations = false, enableExport = true, customActions } = config;
   
     // Use the new hook
   const crudActions = useCrudTable(rowKey, {
@@ -54,6 +55,8 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
   const [currentRecord, setCurrentRecord] = useState<Partial<T> | null>(null);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [form] = Form.useForm();
+  // What the table currently shows (the latest request response), for export
+  const visibleDataRef = useRef<T[]>([]);
 
   // Enhanced columns: base props + whatever the field-type registry adds
   const enhancedColumns: ProColumns<T>[] = columns.map((col) => {
@@ -121,18 +124,20 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
       const { operations } = crudActions;
       if (operations.getList) {
         const response = await operations.getList(query);
-        return { 
-          data: response.data, 
-          success: true, 
-          total: response.total 
+        visibleDataRef.current = response.data ?? [];
+        return {
+          data: response.data,
+          success: true,
+          total: response.total
         };
       }
-      
+
       // Fallback to current state
-      return { 
-        data: crudActions.state.data, 
-        success: true, 
-        total: crudActions.state.total 
+      visibleDataRef.current = crudActions.state.data;
+      return {
+        data: crudActions.state.data,
+        success: true,
+        total: crudActions.state.total
       };
     } catch (error) {
       message.error('Failed to fetch data');
@@ -234,6 +239,27 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
     });
   };
 
+  const handleExport = (format: ExportFormat) => {
+    const data = visibleDataRef.current;
+    if (data.length === 0) {
+      message.warning('Nothing to export');
+      return;
+    }
+
+    // Password values never leave the table masked, so skip them entirely
+    const exportColumns = columns
+      .filter((col) => col.dataIndex && col.fieldType !== 'password')
+      .map((col) => ({
+        title: typeof col.title === 'string' ? col.title : String(col.dataIndex),
+        dataIndex: String(col.dataIndex),
+        fieldType: col.fieldType,
+        enumOptions: col.enumOptions,
+      }));
+
+    const filename = title ? title.toLowerCase().replace(/\s+/g, '-') : 'export';
+    exportData({ data, columns: exportColumns, filename, format });
+  };
+
   const rowSelection = enableBulkOperations ? {
     selectedRowKeys,
     onChange: setSelectedRowKeys,
@@ -277,11 +303,12 @@ const CrudTable = <T extends DataType>(config: CrudTableConfig<T>) => {
             key="menu"
             menu={{
               items: [
-                { 
-                  key: 'export', 
-                  label: 'Export',
-                  disabled: true, // TODO: Implement export
-                },
+                ...(enableExport ? [
+                  { key: 'export-csv', label: 'Export CSV', onClick: () => handleExport('csv') },
+                  { key: 'export-json', label: 'Export JSON', onClick: () => handleExport('json') },
+                  { key: 'export-excel', label: 'Export Excel', onClick: () => handleExport('xlsx') },
+                  { type: 'divider' as const },
+                ] : []),
                 {
                   key: 'refresh',
                   label: 'Refresh',

--- a/lib/utils/exportData.ts
+++ b/lib/utils/exportData.ts
@@ -97,7 +97,11 @@ export const exportToJSON = <T>(options: ExportOptions<T>): void => {
 };
 
 /**
- * Export data to XLSX format (using simple XML format)
+ * Export data as an Excel-compatible spreadsheet.
+ *
+ * Emits Excel 2003 SpreadsheetML (an XML dialect Excel and LibreOffice
+ * open natively from a .xls file) rather than a real OOXML .xlsx, which
+ * would require a dedicated dependency such as exceljs.
  */
 export const exportToXLSX = <T extends Record<string, any>>(options: ExportOptions<T>): void => {
   const { data, columns, filename = 'export' } = options;
@@ -110,8 +114,8 @@ export const exportToXLSX = <T extends Record<string, any>>(options: ExportOptio
   // Prepare headers
   const headers = visibleColumns.map(col => String(col.title || col.dataIndex));
 
-  // Prepare data rows
-  const rows = data.map(record => {
+  // Prepare data rows, keeping numbers as numbers so Excel treats them as such
+  const rows: (string | number)[][] = data.map(record => {
     return visibleColumns.map(col => {
       const value = record[col.dataIndex as keyof T];
       if (value === null || value === undefined) return '';
@@ -123,44 +127,47 @@ export const exportToXLSX = <T extends Record<string, any>>(options: ExportOptio
         const option = col.enumOptions[value as string];
         return option?.text || String(value);
       }
+      if (typeof value === 'number') {
+        return value;
+      }
 
       return String(value);
     });
   });
 
-  // Create XLSX content (simple XML format)
-  const createXLSX = () => {
-    const escapeXml = (str: string): string => {
-      return str
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&apos;');
-    };
-
-    const headersXml = headers.map(h => `<c t="inlineStr"><is><t>${escapeXml(h)}</t></is></c>`).join('');
-    const rowsXml = rows.map(row =>
-      `<row>${row.map(cell => `<c t="inlineStr"><is><t>${escapeXml(String(cell))}</t></is></c>`).join('')}</row>`
-    ).join('');
-
-    return `<?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="stylesheet.xsl"?>
-<workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet">
-  <sheets>
-    <sheet name="Export">
-      <table>
-        <row>${headersXml}</row>
-        ${rowsXml}
-      </table>
-    </sheet>
-  </sheets>
-</workbook>`;
+  const escapeXml = (str: string): string => {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
   };
 
-  // Create a simple Excel XML file
-  const xlsxContent = createXLSX();
-  downloadFile(xlsxContent, `${filename}.xls`, 'application/vnd.ms-excel');
+  const cellXml = (cell: string | number): string => {
+    const type = typeof cell === 'number' ? 'Number' : 'String';
+    const content = typeof cell === 'number' ? String(cell) : escapeXml(cell);
+    return `<Cell><Data ss:Type="${type}">${content}</Data></Cell>`;
+  };
+
+  const headerXml = `<Row>${headers.map(h => cellXml(h)).join('')}</Row>`;
+  const rowsXml = rows
+    .map(row => `<Row>${row.map(cell => cellXml(cell)).join('')}</Row>`)
+    .join('\n');
+
+  const xlsContent = `<?xml version="1.0"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+ <Worksheet ss:Name="Export">
+  <Table>
+${headerXml}
+${rowsXml}
+  </Table>
+ </Worksheet>
+</Workbook>`;
+
+  downloadFile(xlsContent, `${filename}.xls`, 'application/vnd.ms-excel');
 };
 
 /**


### PR DESCRIPTION
Closes #6

> **Stacked on #13** — merge order: #9 → #10 → #11 → #12 → #13 → this.

## What

**1. Excel export actually opens in Excel now.** The old `exportToXLSX` mixed OOXML inline-string cells with an invented `<sheets><sheet><table>` structure — neither Excel nor LibreOffice could read it. It now emits proper Excel 2003 SpreadsheetML (`<?mso-application progid="Excel.Sheet"?>` + `Workbook/Worksheet/Table/Row/Cell/Data`), keeps numeric cells typed as numbers, and downloads as `.xls`. (A true OOXML `.xlsx` would need `exceljs`/`xlsx` as a dependency — deliberately out of scope, documented in the docstring.)

**2. The toolbar Export menu works.** The permanently-disabled "Export" TODO entry is replaced by CSV / JSON / Excel entries that export the rows the table currently shows (tracked from the latest `request` response), with column titles and enum labels respected, password columns skipped, and the file named after the table title. The pre-existing `enableExport` config flag — declared but never read until now — gates the menu.

## Verification

- `tsc --noEmit` and `pnpm build:lib` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
