### PR TITLE
[chore]: package hygiene - working exports map, one date library, typed lazy wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ Customize row striping using `.row-differentiator` in `CrudTable.css`:
 
 ## 📌 Notes
 
-- Date fields are handled via `dayjs` in the form and `date-fns` for display.
+- Date fields are handled via `dayjs` (already required by antd) in both the form and display.
 - All requests are async with error handling via `antd`'s `message` API.
 - Add your own export logic or additional toolbar buttons as needed.
 

--- a/lib/CrudTableLazy.tsx
+++ b/lib/CrudTableLazy.tsx
@@ -1,20 +1,20 @@
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, type ComponentType } from 'react';
 import type { CrudTableConfig, DataType } from './CrudTable';
 
-const CrudTable = lazy(() => import('./CrudTable'));
+// React.lazy erases generics, so restore the component signature once here
+// instead of casting props at every call site
+const CrudTable = lazy(() => import('./CrudTable')) as ComponentType<CrudTableConfig<any>>;
 
 const CrudTableLazy = <T extends DataType>(props: CrudTableConfig<T>) => {
   return (
     <Suspense
       fallback={
         <div style={{ textAlign: 'center', padding: '2rem' }}>
-          Loading curd table w antd
+          Loading CRUD table…
         </div>
       }
     >
-      <CrudTable
-        {...(props as any)}
-      />
+      <CrudTable {...props} />
     </Suspense>
   );
 };

--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -89,7 +89,7 @@ export type CrudTableActions<T> = {
 
   // State
   state: CrudState<T>;
-  actionRef: React.RefObject<ActionType | null>;
+  actionRef: React.MutableRefObject<ActionType | undefined>;
 };
 
 // Default API operations
@@ -204,7 +204,7 @@ export const useCrudTable = <T extends Record<string, any>>(
   rowKey: keyof T,
   config: UseCrudTableConfig<T>
 ): CrudTableActions<T> => {
-  const actionRef = useRef<ActionType>(null);
+  const actionRef = useRef<ActionType | undefined>(undefined);
   const [state, setState] = useState<CrudState<T>>({
     loading: false,
     error: null,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,9 @@
 // Main components
 export { default as CrudTable } from './CrudTable';
 export { default as CrudTableLazy } from './CrudTableLazy';
+// Default export kept so `import CrudTable from 'antd-crud-table'`
+// (the pre-barrel entry behaviour) keeps working
+export { default } from './CrudTable';
 
 // Hooks
 export { useCrudTable } from './hooks/useCrudTable';

--- a/package.json
+++ b/package.json
@@ -51,11 +51,16 @@
     "vite": "^8.0.8",
     "vite-plugin-dts": "^4.5.3"
   },
-  "main": "./dist/CrudTable.cjs",
-  "module": "./dist/CrudTable.js",
-  "types": "./dist/CrudTable.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./CrudTable": {
       "types": "./dist/CrudTable.d.ts",
       "import": "./dist/CrudTable.js",
       "require": "./dist/CrudTable.cjs"
@@ -71,11 +76,16 @@
       "require": "./dist/useCrudTable.cjs"
     },
     "./hooks/useLocalStorageCrud": {
-      "types": "./dist/hooks/useLocalStorageCrud.d.ts"
+      "types": "./dist/hooks/useLocalStorageCrud.d.ts",
+      "import": "./dist/useLocalStorageCrud.js",
+      "require": "./dist/useLocalStorageCrud.cjs"
     },
     "./utils/exportData": {
-      "types": "./dist/utils/exportData.d.ts"
-    }
+      "types": "./dist/utils/exportData.d.ts",
+      "import": "./dist/exportData.js",
+      "require": "./dist/exportData.cjs"
+    },
+    "./styles.css": "./dist/antd-crud-table.css"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@ant-design/icons": "^6.0.0",
     "@ant-design/pro-components": "^2.8.10",
     "antd": "^6.3.6",
-    "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@types/node": "^22.15.2",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react-swc": "^3.8.0",
     "eslint": "^9.22.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       antd:
         specifier: ^6.3.6
         version: 6.3.6(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -31,11 +28,11 @@ importers:
         specifier: ^22.15.2
         version: 22.15.2
       '@types/react':
-        specifier: ^19.0.10
-        version: 19.1.2
+        specifier: ^18.3.18
+        version: 18.3.31
       '@types/react-dom':
-        specifier: ^19.0.4
-        version: 19.1.2(@types/react@19.1.2)
+        specifier: ^18.3.5
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react-swc':
         specifier: ^3.8.0
         version: 3.9.0(vite@8.0.8(@types/node@22.15.2))
@@ -991,13 +988,16 @@ packages:
   '@types/node@22.15.2':
     resolution: {integrity: sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==}
 
-  '@types/react-dom@19.1.2':
-    resolution: {integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==}
-    peerDependencies:
-      '@types/react': ^19.0.0
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react@19.1.2':
-    resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@typescript-eslint/eslint-plugin@8.31.0':
     resolution: {integrity: sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==}
@@ -1201,6 +1201,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -3025,13 +3028,16 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@19.1.2(@types/react@19.1.2)':
-    dependencies:
-      '@types/react': 19.1.2
+  '@types/prop-types@15.7.15': {}
 
-  '@types/react@19.1.2':
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
     dependencies:
-      csstype: 3.1.3
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1)(typescript@5.7.3))(eslint@9.25.1)(typescript@5.7.3)':
     dependencies:
@@ -3326,7 +3332,10 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  date-fns@4.1.0: {}
+  csstype@3.2.3: {}
+
+  date-fns@4.1.0:
+    optional: true
 
   dayjs@1.11.13: {}
 

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -30,6 +30,7 @@ export default defineConfig({
   build: {
     lib: {
       entry: [
+        path.resolve(__dirname, 'lib/index.ts'),
         path.resolve(__dirname, 'lib/CrudTable.tsx'),
         path.resolve(__dirname, 'lib/CrudTableLazy.tsx'),
         path.resolve(__dirname, 'lib/hooks/useCrudTable.ts'),

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -10,7 +10,6 @@ const peerDeps = [
   'antd',
   '@ant-design/icons',
   '@ant-design/pro-components',
-  'date-fns',
   'dayjs',
 ];
 


### PR DESCRIPTION
Closes #7

> **Stacked on #14** — merge order: #9 → #10 → #11 → #12 → #13 → #14 → this.

## What

1. **Package entry/exports actually resolve now.**
   - `lib/index.ts` (the barrel the README documents) is now a build entry and the package root, so `import { CrudTable } from 'antd-crud-table'` works; it also re-exports the component as `default` so existing `import CrudTable from 'antd-crud-table'` keeps working.
   - `./hooks/useLocalStorageCrud` and `./utils/exportData` had `types`-only export entries — they type-checked but **failed to resolve at runtime**. Every subpath now maps to its built ESM/CJS files + matching `.d.ts`.
   - The extracted stylesheet is importable as `antd-crud-table/styles.css`.
   - Verified post-build that every `exports` target exists in `dist/`.
2. **`date-fns` peer dependency dropped** — since #13 the registry renders dates via `dayjs` (already required by antd), so nothing imports `date-fns` anymore. Removed from peers, build externals and README.
3. **Lazy wrapper cleanup** — "Loading curd table w antd" typo fixed; the unavoidable `React.lazy` generics cast moved to the component definition instead of `{...(props as any)}`.
4. **React types aligned** — `@types/react`/`@types/react-dom` pinned back to `^18` to match the dev/peer React major; `actionRef` retyped to what ProTable accepts under both type majors.

## Verification

- `tsc` (lib + app) and `pnpm build:lib` pass; an exports-target existence check runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
