### PR TITLE
[version]: set version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "antd-crud-table",
   "private": false,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "homepage": "https://github.com/maifeeulasad/antd-crud-table",
   "repository": {


### PR DESCRIPTION
Version bump for the 0.5.0 release covering PRs #9–#16 and #18. Release notes go on the GitHub release (which triggers the npm publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)