### PR TITLE
[architecture]: add CrudDataSource core with class-based strategies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,18 @@ export default tseslint.config(
       // Record<string, unknown> constraints. Keep the rule visible as a
       // warning so new accidental `any`s still surface without failing CI.
       '@typescript-eslint/no-explicit-any': 'warn',
+      // A leading underscore marks a binding that is deliberately unused.
+      // Overridable base-class methods must keep their full parameter list
+      // for subclass overrides to remain type-compatible, even where the
+      // base implementation ignores them.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
     },
   },
 )

--- a/lib/core/CustomDataSource.test.ts
+++ b/lib/core/CustomDataSource.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { CustomDataSource, UnsupportedOperationError } from './CustomDataSource';
+
+interface Row { id: number; name: string }
+
+describe('CustomDataSource', () => {
+  it('delegates to the supplied operations', async () => {
+    const list = vi.fn().mockResolvedValue({ items: [{ id: 1, name: 'a' }], total: 1 });
+    const source = new CustomDataSource<Row, 'id'>({ list });
+
+    const page = await source.list({ page: 1, pageSize: 10 });
+
+    expect(list).toHaveBeenCalledWith({ page: 1, pageSize: 10 });
+    expect(page.total).toBe(1);
+  });
+
+  it('names the missing operation instead of failing on undefined', async () => {
+    const source = new CustomDataSource<Row, 'id'>({});
+
+    await expect(source.create({ name: 'x' })).rejects.toThrow(UnsupportedOperationError);
+    await expect(source.create({ name: 'x' })).rejects.toThrow(/does not support "create"/);
+    await expect(source.update(1, {})).rejects.toThrow(/does not support "update"/);
+    await expect(source.remove(1)).rejects.toThrow(/does not support "remove"/);
+    await expect(source.list({ page: 1, pageSize: 10 })).rejects.toThrow(/does not support "list"/);
+  });
+
+  it('reports which operations are available', () => {
+    const source = new CustomDataSource<Row, 'id'>({ list: vi.fn(), create: vi.fn() });
+
+    expect(source.supports('list')).toBe(true);
+    expect(source.supports('create')).toBe(true);
+    expect(source.supports('remove')).toBe(false);
+  });
+});

--- a/lib/core/CustomDataSource.ts
+++ b/lib/core/CustomDataSource.ts
@@ -1,0 +1,71 @@
+import type { CrudDataSource, CrudDraft, CrudPage, CrudQuery } from './types';
+
+/**
+ * The operations a consumer may supply. Every entry is optional so a
+ * read-only table need not invent write handlers it will never call.
+ */
+export type CrudOperations<T, K extends keyof T> = Partial<CrudDataSource<T, K>>;
+
+/**
+ * Raised when the table attempts an operation the consumer did not supply.
+ *
+ * Names the missing operation so the message points at the fix rather than
+ * surfacing as `undefined is not a function`.
+ */
+export class UnsupportedOperationError extends Error {
+  readonly operation: string;
+
+  constructor(operation: string) {
+    super(
+      `This table's data source does not support "${operation}". ` +
+        `Provide an \`${operation}\` operation to enable it.`,
+    );
+    this.name = 'UnsupportedOperationError';
+    this.operation = operation;
+  }
+}
+
+/**
+ * Adapts a bag of consumer-supplied functions to the full interface.
+ *
+ * Exists so the rest of the library can depend on `CrudDataSource` without
+ * null-checking each method at every call site; absent operations fail here
+ * with a message naming what is missing.
+ */
+export class CustomDataSource<T extends object, K extends keyof T> implements CrudDataSource<T, K> {
+  private readonly operations: CrudOperations<T, K>;
+
+  constructor(operations: CrudOperations<T, K>) {
+    this.operations = operations;
+  }
+
+  /** Whether an operation was supplied, so callers can hide unavailable UI. */
+  supports(operation: keyof CrudDataSource<T, K>): boolean {
+    return typeof this.operations[operation] === 'function';
+  }
+
+  async list(query: CrudQuery<T>): Promise<CrudPage<T>> {
+    if (!this.operations.list) throw new UnsupportedOperationError('list');
+    return this.operations.list(query);
+  }
+
+  async listAll(query: Omit<CrudQuery<T>, 'page' | 'pageSize'>): Promise<readonly T[]> {
+    if (this.operations.listAll) return this.operations.listAll(query);
+    throw new UnsupportedOperationError('listAll');
+  }
+
+  async create(draft: CrudDraft<T>): Promise<T> {
+    if (!this.operations.create) throw new UnsupportedOperationError('create');
+    return this.operations.create(draft);
+  }
+
+  async update(id: T[K], draft: CrudDraft<T>): Promise<T> {
+    if (!this.operations.update) throw new UnsupportedOperationError('update');
+    return this.operations.update(id, draft);
+  }
+
+  async remove(id: T[K]): Promise<void> {
+    if (!this.operations.remove) throw new UnsupportedOperationError('remove');
+    return this.operations.remove(id);
+  }
+}

--- a/lib/core/InMemoryDataSource.ts
+++ b/lib/core/InMemoryDataSource.ts
@@ -1,0 +1,87 @@
+import { queryRecords } from './inMemoryQuery';
+import { defaultIdGenerator } from './identity';
+import type { CrudDataSource, CrudDraft, CrudPage, CrudQuery, IdGenerator } from './types';
+import { filterRecords, sortRecords } from './inMemoryQuery';
+
+/**
+ * Shared behaviour for every source backed by a local collection.
+ *
+ * Subclasses supply only where the records live, via `read`/`write`. All
+ * querying, identity assignment and mutation semantics are defined once here
+ * so the static and localStorage strategies cannot drift apart.
+ */
+export abstract class InMemoryDataSource<T extends object, K extends keyof T>
+  implements CrudDataSource<T, K>
+{
+  protected readonly key: K;
+  protected readonly generateId: IdGenerator<T, K>;
+
+  protected constructor(key: K, generateId?: IdGenerator<T, K>) {
+    this.key = key;
+    this.generateId = generateId ?? defaultIdGenerator<T, K>(key);
+  }
+
+  /** Current contents of the backing collection. */
+  protected abstract read(): readonly T[];
+
+  /** Replace the backing collection. */
+  protected abstract write(records: readonly T[]): void;
+
+  /**
+   * Hook for values a subclass stamps onto every write, such as timestamps.
+   * Returns nothing extra by default.
+   */
+  protected decorate(_record: CrudDraft<T>, _operation: 'create' | 'update'): CrudDraft<T> {
+    return {};
+  }
+
+  private indexOf(id: T[K]): number {
+    return this.read().findIndex((record) => record[this.key] === id);
+  }
+
+  async list(query: CrudQuery<T>): Promise<CrudPage<T>> {
+    return queryRecords(this.read(), query);
+  }
+
+  async listAll(query: Omit<CrudQuery<T>, 'page' | 'pageSize'>): Promise<readonly T[]> {
+    return sortRecords(filterRecords(this.read(), query.filters), query.sort);
+  }
+
+  async create(draft: CrudDraft<T>): Promise<T> {
+    const records = this.read();
+    const record = {
+      [this.key]: this.generateId(records),
+      ...draft,
+      ...this.decorate(draft, 'create'),
+    } as T;
+
+    this.write([...records, record]);
+    return record;
+  }
+
+  async update(id: T[K], draft: CrudDraft<T>): Promise<T> {
+    const records = this.read();
+    const index = this.indexOf(id);
+    if (index === -1) throw new Error(`No record with ${String(this.key)} "${String(id)}"`);
+
+    // The identity is never taken from the draft: allowing a write to move a
+    // record's key would orphan it from the id the caller is updating.
+    const updated = {
+      ...records[index],
+      ...draft,
+      ...this.decorate(draft, 'update'),
+      [this.key]: id,
+    } as T;
+
+    const next = [...records];
+    next[index] = updated;
+    this.write(next);
+    return updated;
+  }
+
+  async remove(id: T[K]): Promise<void> {
+    const records = this.read();
+    if (this.indexOf(id) === -1) throw new Error(`No record with ${String(this.key)} "${String(id)}"`);
+    this.write(records.filter((record) => record[this.key] !== id));
+  }
+}

--- a/lib/core/LocalStorageDataSource.test.ts
+++ b/lib/core/LocalStorageDataSource.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+import { LocalStorageDataSource } from './LocalStorageDataSource';
+
+interface Note { id: number; text: string; createdAt?: string; updatedAt?: string }
+
+const KEY = 'notes';
+const seed: Note[] = [{ id: 1, text: 'first' }];
+
+const make = () => new LocalStorageDataSource<Note, 'id'>(KEY, 'id', seed);
+const stored = (): Note[] => JSON.parse(localStorage.getItem(KEY) ?? '[]');
+
+beforeEach(() => localStorage.clear());
+afterEach(() => vi.restoreAllMocks());
+
+describe('LocalStorageDataSource', () => {
+  it('falls back to the seed when nothing is stored', async () => {
+    expect((await make().list({ page: 1, pageSize: 10 })).total).toBe(1);
+  });
+
+  it('persists creates to storage', async () => {
+    const created = await make().create({ text: 'second' });
+
+    expect(created.id).toBe(2);
+    expect(stored().map((n) => n.text)).toEqual(['first', 'second']);
+  });
+
+  it('stamps createdAt and updatedAt on create', async () => {
+    const created = await make().create({ text: 'x' });
+    expect(created.createdAt).toBeTypeOf('string');
+    expect(created.updatedAt).toBe(created.createdAt);
+  });
+
+  it('advances updatedAt on update but preserves createdAt', async () => {
+    const source = make();
+    const created = await source.create({ text: 'x' });
+
+    vi.setSystemTime(new Date(Date.parse(created.createdAt!) + 5000));
+    const updated = await source.update(created.id, { text: 'y' });
+
+    expect(updated.createdAt).toBe(created.createdAt);
+    expect(updated.updatedAt).not.toBe(created.updatedAt);
+    vi.useRealTimers();
+  });
+
+  it('sees writes made by another instance on the same key', async () => {
+    await make().create({ text: 'from A' });
+    expect((await make().list({ page: 1, pageSize: 10 })).total).toBe(2);
+  });
+
+  it('falls back to the seed when the stored value is malformed', async () => {
+    localStorage.setItem(KEY, '{not json');
+    expect((await make().list({ page: 1, pageSize: 10 })).total).toBe(1);
+  });
+
+  it('falls back to the seed when the stored value is not an array', async () => {
+    localStorage.setItem(KEY, '{"nope":true}');
+    expect((await make().list({ page: 1, pageSize: 10 })).total).toBe(1);
+  });
+
+  // A read failure degrades; a write failure must not, or the user is told a
+  // save succeeded when nothing was persisted.
+  it('throws when a write cannot be persisted', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    await expect(make().create({ text: 'x' })).rejects.toThrow(/Failed to persist.*QuotaExceededError/);
+  });
+
+  it('removes by id', async () => {
+    const source = make();
+    await source.create({ text: 'second' });
+    await source.remove(1);
+
+    expect(stored().map((n) => n.id)).toEqual([2]);
+  });
+});

--- a/lib/core/LocalStorageDataSource.ts
+++ b/lib/core/LocalStorageDataSource.ts
@@ -1,0 +1,70 @@
+import { InMemoryDataSource } from './InMemoryDataSource';
+import type { CrudDraft, IdGenerator } from './types';
+
+/** Fields stamped onto records by the localStorage strategy. */
+export interface Timestamped {
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * A source persisting to `localStorage` under a fixed key.
+ *
+ * Reads go through storage on every call rather than through a cache, so a
+ * second tab writing the same key is picked up on the next query instead of
+ * being shadowed by stale in-memory state.
+ *
+ * Storage is best-effort: a read that fails or returns malformed JSON falls
+ * back to the seed rather than throwing, since an unreadable cache should not
+ * take the table down. Writes that fail (quota, private mode) *do* throw -
+ * silently dropping a write the user believes succeeded is worse than an error.
+ */
+export class LocalStorageDataSource<
+  T extends object,
+  K extends keyof T,
+> extends InMemoryDataSource<T, K> {
+  private readonly storageKey: string;
+  private readonly seed: readonly T[];
+
+  constructor(storageKey: string, key: K, seed: readonly T[] = [], generateId?: IdGenerator<T, K>) {
+    super(key, generateId);
+    this.storageKey = storageKey;
+    this.seed = seed;
+  }
+
+  protected read(): readonly T[] {
+    let raw: string | null;
+    try {
+      raw = localStorage.getItem(this.storageKey);
+    } catch {
+      return this.seed;
+    }
+    if (raw === null) return this.seed;
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return Array.isArray(parsed) ? (parsed as T[]) : this.seed;
+    } catch {
+      return this.seed;
+    }
+  }
+
+  protected write(records: readonly T[]): void {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(records));
+    } catch (error) {
+      throw new Error(
+        `Failed to persist to localStorage key "${this.storageKey}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  /** Stamps creation and modification times onto every write. */
+  protected decorate(_draft: CrudDraft<T>, operation: 'create' | 'update'): CrudDraft<T> {
+    const now = new Date().toISOString();
+    const stamps: Timestamped = operation === 'create' ? { createdAt: now, updatedAt: now } : { updatedAt: now };
+    return stamps as CrudDraft<T>;
+  }
+}

--- a/lib/core/RestDataSource.test.ts
+++ b/lib/core/RestDataSource.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { RestDataSource, RestError } from './RestDataSource';
+import type { CrudPage } from './types';
+
+interface User { id: number; name: string }
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+/** Records calls and replies with a scripted queue of responses. */
+const stubFetch = (...responses: Response[]) => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const queue = [...responses];
+  const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return queue.shift() ?? json({});
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+};
+
+describe('RestDataSource', () => {
+  it('builds a list url with pagination, sort and filters', async () => {
+    const { impl, calls } = stubFetch(json({ data: [], total: 0 }));
+    const source = new RestDataSource<User, 'id'>({ baseUrl: '/api', fetchImpl: impl });
+
+    await source.list({
+      page: 2,
+      pageSize: 25,
+      sort: [{ field: 'name', direction: 'descend' }],
+      filters: { name: 'ali' },
+    });
+
+    const url = new URL(calls[0].url, 'http://x');
+    expect(url.pathname).toBe('/api/list');
+    expect(url.searchParams.get('current')).toBe('2');
+    expect(url.searchParams.get('pageSize')).toBe('25');
+    expect(url.searchParams.get('sortBy')).toBe('name');
+    expect(url.searchParams.get('sortOrder')).toBe('descend');
+    expect(url.searchParams.get('name')).toBe('ali');
+  });
+
+  // Regression guard: building a full url early and prefixing baseUrl again in
+  // the fetch helper is how a relative base ended up duplicated in the path.
+  it('applies baseUrl exactly once', async () => {
+    const { impl, calls } = stubFetch(json([]));
+    await new RestDataSource<User, 'id'>({ baseUrl: '/api', fetchImpl: impl }).list({ page: 1, pageSize: 10 });
+
+    expect(calls[0].url.startsWith('/api/list')).toBe(true);
+    expect(calls[0].url).not.toContain('/api/api');
+  });
+
+  it('omits empty filter values from the query string', async () => {
+    const { impl, calls } = stubFetch(json([]));
+    const source = new RestDataSource<User, 'id'>({ fetchImpl: impl });
+
+    await source.list({ page: 1, pageSize: 10, filters: { name: '' } });
+
+    expect(calls[0].url).not.toContain('name=');
+  });
+
+  it('accepts a bare array response', async () => {
+    const { impl } = stubFetch(json([{ id: 1, name: 'a' }, { id: 2, name: 'b' }]));
+    const page = await new RestDataSource<User, 'id'>({ fetchImpl: impl }).list({ page: 1, pageSize: 10 });
+
+    expect(page.items).toHaveLength(2);
+    expect(page.total).toBe(2);
+  });
+
+  it('accepts the { data, total } envelope', async () => {
+    const { impl } = stubFetch(json({ data: [{ id: 1, name: 'a' }], total: 57 }));
+    const page = await new RestDataSource<User, 'id'>({ fetchImpl: impl }).list({ page: 1, pageSize: 10 });
+
+    expect(page.total).toBe(57);
+  });
+
+  it('uses a supplied parseResponse for unusual envelopes', async () => {
+    const { impl } = stubFetch(json({ results: { rows: [{ id: 9, name: 'z' }], count: 3 } }));
+    const parseResponse = (payload: unknown): CrudPage<User> => {
+      const { results } = payload as { results: { rows: User[]; count: number } };
+      return { items: results.rows, total: results.count };
+    };
+
+    const page = await new RestDataSource<User, 'id'>({ fetchImpl: impl, parseResponse }).list({
+      page: 1,
+      pageSize: 10,
+    });
+
+    expect(page.items[0].id).toBe(9);
+    expect(page.total).toBe(3);
+  });
+
+  it('explains an unrecognised envelope instead of returning undefined rows', async () => {
+    const { impl } = stubFetch(json({ mystery: true }));
+    await expect(
+      new RestDataSource<User, 'id'>({ fetchImpl: impl }).list({ page: 1, pageSize: 10 }),
+    ).rejects.toThrow(/Provide `parseResponse`/);
+  });
+
+  it('throws a RestError carrying the status and body', async () => {
+    const { impl } = stubFetch(new Response('{"field":"name"}', { status: 422 }));
+    const source = new RestDataSource<User, 'id'>({ baseUrl: '/api', fetchImpl: impl });
+
+    const error = await source.list({ page: 1, pageSize: 10 }).then(
+      () => { throw new Error('expected the request to reject'); },
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(RestError);
+    expect((error as RestError).status).toBe(422);
+    expect((error as RestError).body).toBe('{"field":"name"}');
+    expect((error as RestError).message).toContain('/api/list');
+  });
+
+  it('sends configured methods and headers', async () => {
+    const { impl, calls } = stubFetch(json({ id: 1, name: 'a' }));
+    const source = new RestDataSource<User, 'id'>({
+      fetchImpl: impl,
+      methods: { update: 'PATCH' },
+      headers: { Authorization: 'Bearer t' },
+    });
+
+    await source.update(1, { name: 'a' });
+
+    expect(calls[0].init?.method).toBe('PATCH');
+    expect(calls[0].url).toContain('/update/1');
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer t');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('renames pagination params for APIs with a different vocabulary', async () => {
+    const { impl, calls } = stubFetch(json([]));
+    const source = new RestDataSource<User, 'id'>({
+      fetchImpl: impl,
+      paramNames: { page: 'page', pageSize: 'limit' },
+    });
+
+    await source.list({ page: 3, pageSize: 50 });
+
+    const url = new URL(calls[0].url, 'http://x');
+    expect(url.searchParams.get('page')).toBe('3');
+    expect(url.searchParams.get('limit')).toBe('50');
+    expect(url.searchParams.has('current')).toBe(false);
+  });
+
+  it('percent-encodes ids in the path', async () => {
+    const { impl, calls } = stubFetch(json({}));
+    await new RestDataSource<{ id: string; name: string }, 'id'>({ fetchImpl: impl }).remove('a/b c');
+
+    expect(calls[0].url).toContain('/delete/a%2Fb%20c');
+  });
+
+  it('tolerates an empty 204 body on remove', async () => {
+    const { impl } = stubFetch(new Response(null, { status: 204 }));
+    await expect(new RestDataSource<User, 'id'>({ fetchImpl: impl }).remove(1)).resolves.toBeUndefined();
+  });
+
+  it('maps the draft through serializeRequest', async () => {
+    const { impl, calls } = stubFetch(json({ id: 1, name: 'a' }));
+    const source = new RestDataSource<User, 'id'>({
+      fetchImpl: impl,
+      serializeRequest: (draft) => ({ payload: draft }),
+    });
+
+    await source.create({ name: 'a' });
+
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ payload: { name: 'a' } });
+  });
+
+  it('is extensible by subclass for non-standard url shapes', async () => {
+    const { impl, calls } = stubFetch(json({ id: 1, name: 'a' }));
+
+    class QueryParamIds extends RestDataSource<User, 'id'> {
+      protected buildRecordPath(endpoint: string, id: number): string {
+        return `${endpoint}?id=${id}`;
+      }
+    }
+
+    await new QueryParamIds({ fetchImpl: impl }).update(7, { name: 'a' });
+
+    expect(calls[0].url).toBe('/update?id=7');
+  });
+});

--- a/lib/core/RestDataSource.ts
+++ b/lib/core/RestDataSource.ts
@@ -1,0 +1,214 @@
+import type { CrudDataSource, CrudDraft, CrudPage, CrudQuery, CrudSort } from './types';
+
+/** Paths appended to `baseUrl` for each operation. */
+export interface RestEndpoints {
+  list: string;
+  create: string;
+  update: string;
+  remove: string;
+}
+
+/** Query-string parameter names, for APIs that do not speak ProTable's vocabulary. */
+export interface RestParamNames {
+  page: string;
+  pageSize: string;
+  sortBy: string;
+  sortOrder: string;
+}
+
+/** HTTP verbs used per mutating operation. */
+export interface RestMethods {
+  create: 'POST' | 'PUT';
+  update: 'PUT' | 'PATCH' | 'POST';
+  remove: 'DELETE' | 'POST';
+}
+
+export interface RestDataSourceOptions<T> {
+  baseUrl?: string;
+  endpoints?: Partial<RestEndpoints>;
+  paramNames?: Partial<RestParamNames>;
+  methods?: Partial<RestMethods>;
+  headers?: Readonly<Record<string, string>>;
+  /** Maps a draft onto the request body. Defaults to sending the draft as-is. */
+  serializeRequest?: (draft: CrudDraft<T>) => unknown;
+  /** Maps a list response onto a page. Required when the API wraps its payload. */
+  parseResponse?: (payload: unknown) => CrudPage<T>;
+  /** Injected for testing; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_ENDPOINTS: RestEndpoints = {
+  list: '/list',
+  create: '/create',
+  update: '/update',
+  remove: '/delete',
+};
+
+const DEFAULT_PARAM_NAMES: RestParamNames = {
+  page: 'current',
+  pageSize: 'pageSize',
+  sortBy: 'sortBy',
+  sortOrder: 'sortOrder',
+};
+
+const DEFAULT_METHODS: RestMethods = {
+  create: 'POST',
+  update: 'PUT',
+  remove: 'DELETE',
+};
+
+/**
+ * Raised when the server answers with a non-2xx status.
+ *
+ * Carries the status and the raw body so consumers can branch on a 409 or
+ * surface a validation payload, rather than receiving a flattened string.
+ */
+export class RestError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(status: number, body: string, url: string) {
+    super(`Request to ${url} failed with status ${status}`);
+    this.name = 'RestError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * A source over a REST API.
+ *
+ * URL and payload construction live in `protected` methods rather than inline,
+ * so an API that does not match the default dialect is a small subclass
+ * instead of a full reimplementation of the strategy.
+ */
+export class RestDataSource<T extends object, K extends keyof T> implements CrudDataSource<T, K> {
+  protected readonly baseUrl: string;
+  protected readonly endpoints: RestEndpoints;
+  protected readonly paramNames: RestParamNames;
+  protected readonly methods: RestMethods;
+  protected readonly headers: Readonly<Record<string, string>>;
+  protected readonly serializeRequest: (draft: CrudDraft<T>) => unknown;
+  protected readonly parseResponse?: (payload: unknown) => CrudPage<T>;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: RestDataSourceOptions<T> = {}) {
+    this.baseUrl = options.baseUrl ?? '';
+    this.endpoints = { ...DEFAULT_ENDPOINTS, ...options.endpoints };
+    this.paramNames = { ...DEFAULT_PARAM_NAMES, ...options.paramNames };
+    this.methods = { ...DEFAULT_METHODS, ...options.methods };
+    this.headers = options.headers ?? {};
+    this.serializeRequest = options.serializeRequest ?? ((draft) => draft);
+    this.parseResponse = options.parseResponse;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * Encode sort instructions as query parameters.
+   *
+   * Only the first instruction is sent: `sortBy`/`sortOrder` is a single-sort
+   * shape, and inventing a multi-sort encoding would guess at a convention the
+   * server may not share. Override to support one.
+   */
+  protected serializeSort(sort: readonly CrudSort<T>[] | undefined, params: URLSearchParams): void {
+    const primary = sort?.[0];
+    if (!primary) return;
+    params.set(this.paramNames.sortBy, String(primary.field));
+    params.set(this.paramNames.sortOrder, primary.direction);
+  }
+
+  /** Build the list URL, including pagination, sort and filters. */
+  protected buildListUrl(query: CrudQuery<T>): string {
+    const params = new URLSearchParams();
+    params.set(this.paramNames.page, String(query.page));
+    params.set(this.paramNames.pageSize, String(query.pageSize));
+    this.serializeSort(query.sort, params);
+
+    for (const [field, value] of Object.entries(query.filters ?? {})) {
+      if (value !== undefined && value !== null && value !== '') {
+        params.set(field, String(value));
+      }
+    }
+
+    return `${this.endpoints.list}?${params.toString()}`;
+  }
+
+  /** Path addressing a single record. Override for `?id=` style APIs. */
+  protected buildRecordPath(endpoint: string, id: T[K]): string {
+    return `${endpoint}/${encodeURIComponent(String(id))}`;
+  }
+
+  /**
+   * Interpret a list payload.
+   *
+   * Without a `parseResponse`, accepts either a bare array or the
+   * `{ data, total }` shape the previous implementation assumed.
+   */
+  protected toPage(payload: unknown): CrudPage<T> {
+    if (this.parseResponse) return this.parseResponse(payload);
+
+    if (Array.isArray(payload)) {
+      return { items: payload as T[], total: payload.length };
+    }
+
+    if (payload !== null && typeof payload === 'object') {
+      const record = payload as { data?: unknown; total?: unknown };
+      if (Array.isArray(record.data)) {
+        const items = record.data as T[];
+        return { items, total: typeof record.total === 'number' ? record.total : items.length };
+      }
+    }
+
+    throw new Error(
+      'Unrecognised list response. Provide `parseResponse` to map it to { items, total }.',
+    );
+  }
+
+  /**
+   * Single point where `baseUrl`, headers and error handling are applied.
+   *
+   * Every request goes through here so `baseUrl` is prefixed exactly once -
+   * building a full URL earlier and prefixing again is how it ended up
+   * duplicated for relative bases.
+   */
+  protected async request(path: string, init: RequestInit = {}): Promise<unknown> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await this.fetchImpl(url, {
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...this.headers, ...init.headers },
+    });
+
+    if (!response.ok) {
+      throw new RestError(response.status, await response.text().catch(() => ''), url);
+    }
+
+    if (response.status === 204) return undefined;
+
+    const text = await response.text();
+    return text === '' ? undefined : (JSON.parse(text) as unknown);
+  }
+
+  async list(query: CrudQuery<T>): Promise<CrudPage<T>> {
+    return this.toPage(await this.request(this.buildListUrl(query)));
+  }
+
+  async create(draft: CrudDraft<T>): Promise<T> {
+    return (await this.request(this.endpoints.create, {
+      method: this.methods.create,
+      body: JSON.stringify(this.serializeRequest(draft)),
+    })) as T;
+  }
+
+  async update(id: T[K], draft: CrudDraft<T>): Promise<T> {
+    return (await this.request(this.buildRecordPath(this.endpoints.update, id), {
+      method: this.methods.update,
+      body: JSON.stringify(this.serializeRequest(draft)),
+    })) as T;
+  }
+
+  async remove(id: T[K]): Promise<void> {
+    await this.request(this.buildRecordPath(this.endpoints.remove, id), {
+      method: this.methods.remove,
+    });
+  }
+}

--- a/lib/core/StaticDataSource.test.ts
+++ b/lib/core/StaticDataSource.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+
+import { StaticDataSource } from './StaticDataSource';
+
+interface User { id: number; name: string; age?: number }
+interface Doc { uuid: string; title: string }
+
+const seed: User[] = [
+  { id: 1, name: 'Alice', age: 30 },
+  { id: 2, name: 'Bob', age: 25 },
+];
+
+const make = () => new StaticDataSource<User, 'id'>(seed, 'id');
+
+describe('StaticDataSource', () => {
+  it('lists a page with the filtered total', async () => {
+    const page = await make().list({ page: 1, pageSize: 1 });
+    expect(page.items).toHaveLength(1);
+    expect(page.total).toBe(2);
+  });
+
+  it('creates with a generated id and returns the stored record', async () => {
+    const source = make();
+    const created = await source.create({ name: 'Carol' });
+
+    expect(created.id).toBe(3);
+    expect(created.name).toBe('Carol');
+    expect((await source.list({ page: 1, pageSize: 10 })).total).toBe(3);
+  });
+
+  it('merges updates without dropping untouched fields', async () => {
+    const source = make();
+    const updated = await source.update(1, { name: 'Alicia' });
+
+    expect(updated).toEqual({ id: 1, name: 'Alicia', age: 30 });
+  });
+
+  it('refuses to let an update move a record onto a different id', async () => {
+    const source = make();
+    const updated = await source.update(1, { id: 99, name: 'Alicia' } as Partial<User>);
+
+    expect(updated.id).toBe(1);
+    expect((await source.list({ page: 1, pageSize: 10 })).total).toBe(2);
+  });
+
+  it('removes by id', async () => {
+    const source = make();
+    await source.remove(1);
+
+    const page = await source.list({ page: 1, pageSize: 10 });
+    expect(page.total).toBe(1);
+    expect(page.items[0].id).toBe(2);
+  });
+
+  it('reports a missing record rather than failing silently', async () => {
+    const source = make();
+    await expect(source.update(404, { name: 'x' })).rejects.toThrow(/No record with id "404"/);
+    await expect(source.remove(404)).rejects.toThrow(/No record with id "404"/);
+  });
+
+  it('never writes back to the caller seed array', async () => {
+    const original = structuredClone(seed);
+    const source = make();
+
+    await source.create({ name: 'Carol' });
+    await source.update(1, { name: 'Changed' });
+    await source.remove(2);
+
+    expect(seed).toEqual(original);
+  });
+
+  // The regression this class exists for. Previously the working copy lived in
+  // a factory closure keyed on the caller's array identity, so an inline
+  // literal from a component discarded every mutation on each parent render.
+  it('keeps mutations across repeated queries regardless of caller re-renders', async () => {
+    const source = new StaticDataSource<User, 'id'>([{ id: 1, name: 'Alice' }], 'id');
+
+    await source.create({ name: 'Added' });
+    for (let i = 0; i < 5; i += 1) {
+      expect((await source.list({ page: 1, pageSize: 10 })).total).toBe(2);
+    }
+  });
+
+  it('generates collision-free ids for uuid-keyed records', async () => {
+    const source = new StaticDataSource<Doc, 'uuid'>([{ uuid: 'seed-a', title: 't' }], 'uuid');
+
+    const first = await source.create({ title: 'one' });
+    const second = await source.create({ title: 'two' });
+
+    expect(first.uuid).not.toBe(second.uuid);
+    expect((await source.list({ page: 1, pageSize: 10 })).total).toBe(3);
+  });
+
+  it('honours an injected id generator', async () => {
+    let n = 100;
+    const source = new StaticDataSource<User, 'id'>(seed, 'id', () => (n += 1));
+    expect((await source.create({ name: 'x' })).id).toBe(101);
+  });
+
+  it('returns every match for listAll, ignoring pagination', async () => {
+    const source = make();
+    expect(await source.listAll({})).toHaveLength(2);
+    expect(await source.listAll({ filters: { name: 'ali' } })).toHaveLength(1);
+  });
+});

--- a/lib/core/StaticDataSource.ts
+++ b/lib/core/StaticDataSource.ts
@@ -1,0 +1,31 @@
+import { InMemoryDataSource } from './InMemoryDataSource';
+import type { IdGenerator } from './types';
+
+/**
+ * A source over an in-process array, for fixtures, demos and tests.
+ *
+ * The collection is instance state, seeded once from the array passed to the
+ * constructor and never re-read from it. That is the fix for the old
+ * closure-factory behaviour: identity of the caller's array no longer
+ * controls the dataset's lifetime, so passing an inline literal from a
+ * component no longer discards every created and edited row when the parent
+ * happens to re-render.
+ *
+ * The seed array is copied, so mutations never write back to the caller's data.
+ */
+export class StaticDataSource<T extends object, K extends keyof T> extends InMemoryDataSource<T, K> {
+  private records: readonly T[];
+
+  constructor(seed: readonly T[], key: K, generateId?: IdGenerator<T, K>) {
+    super(key, generateId);
+    this.records = [...seed];
+  }
+
+  protected read(): readonly T[] {
+    return this.records;
+  }
+
+  protected write(records: readonly T[]): void {
+    this.records = records;
+  }
+}

--- a/lib/core/identity.test.ts
+++ b/lib/core/identity.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { defaultIdGenerator, randomUuid } from './identity';
+
+interface NumKey { id: number; name: string }
+interface StrKey { uuid: string; name: string }
+
+describe('defaultIdGenerator', () => {
+  it('continues a numeric sequence from the highest key', () => {
+    const next = defaultIdGenerator<NumKey, 'id'>('id');
+    expect(next([{ id: 1, name: 'a' }, { id: 7, name: 'b' }, { id: 3, name: 'c' }])).toBe(8);
+  });
+
+  it('starts at 1 for an empty dataset', () => {
+    expect(defaultIdGenerator<NumKey, 'id'>('id')([])).toBe(1);
+  });
+
+  // The regression this policy exists for: coercing a UUID to a number gave
+  // NaN, `|| 0` collapsed it to 0, and every created row came back as 1.
+  it('produces unique ids for non-numeric string keys instead of colliding on 1', () => {
+    const next = defaultIdGenerator<StrKey, 'uuid'>('uuid');
+    const seed: StrKey[] = [{ uuid: 'a3f9-1111', name: 'a' }];
+
+    const first = next(seed);
+    const second = next([...seed, { uuid: first, name: 'b' }]);
+
+    expect(first).not.toBe(1);
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('keeps digit-like string keys as incremented strings, not numbers', () => {
+    const next = defaultIdGenerator<StrKey, 'uuid'>('uuid');
+    const result = next([{ uuid: '9', name: 'a' }, { uuid: '10', name: 'b' }]);
+    expect(result).toBe('11');
+    expect(typeof result).toBe('string');
+  });
+
+  it('ignores null and undefined keys when deriving the next value', () => {
+    const next = defaultIdGenerator<NumKey, 'id'>('id');
+    const records = [{ id: 4, name: 'a' }, { id: undefined as unknown as number, name: 'b' }];
+    expect(next(records)).toBe(5);
+  });
+
+  it('refuses to guess when key types are mixed', () => {
+    const next = defaultIdGenerator<NumKey, 'id'>('id');
+    const mixed = [{ id: 1, name: 'a' }, { id: 'x' as unknown as number, name: 'b' }];
+    expect(() => next(mixed)).toThrow(/neither all numbers nor all strings/);
+  });
+});
+
+describe('randomUuid', () => {
+  it('emits a well-formed v4 uuid', () => {
+    expect(randomUuid()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('does not repeat across many draws', () => {
+    const seen = new Set(Array.from({ length: 500 }, () => randomUuid()));
+    expect(seen.size).toBe(500);
+  });
+});

--- a/lib/core/identity.ts
+++ b/lib/core/identity.ts
@@ -1,0 +1,81 @@
+import type { IdGenerator } from './types';
+
+/**
+ * Fresh RFC-4122 v4 identifier.
+ *
+ * `crypto.randomUUID` needs a secure context and is absent in some test
+ * environments, so this falls back to `getRandomValues` and, failing that,
+ * to `Math.random`. The fallback is for uniqueness within a client-side
+ * dataset, not for anything security-bearing.
+ */
+const randomUuid = (): string => {
+  const webCrypto: Crypto | undefined =
+    typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : undefined;
+
+  if (webCrypto && typeof webCrypto.randomUUID === 'function') {
+    return webCrypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (webCrypto && typeof webCrypto.getRandomValues === 'function') {
+    webCrypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  // Version 4, variant 10xx, per RFC 4122 section 4.4.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+};
+
+const DIGITS_ONLY = /^\d+$/;
+
+/**
+ * Default identity policy for in-memory sources.
+ *
+ * Chooses from the *runtime type of the existing keys* rather than coercing
+ * them to numbers. Coercion was the old bug: `Number('a3f9-...')` is `NaN`,
+ * `|| 0` collapsed it to `0`, and every created row came back as `1` -
+ * duplicate keys, and `update`/`remove` then resolving to the wrong record.
+ *
+ * - numeric keys      -> highest + 1
+ * - digit-like strings -> highest + 1, kept as a string
+ * - any other string  -> a fresh UUID
+ * - empty dataset     -> `1`, matching the previous behaviour for the common case
+ *
+ * Mixed or non-primitive key types cannot be continued safely, so those throw
+ * rather than silently colliding. Pass an explicit generator for those.
+ */
+export const defaultIdGenerator = <T, K extends keyof T>(key: K): IdGenerator<T, K> => {
+  return (existing: readonly T[]): T[K] => {
+    const keys = existing.map((item) => item[key]).filter((value) => value !== undefined && value !== null);
+
+    if (keys.length === 0) return 1 as T[K];
+
+    if (keys.every((value) => typeof value === 'number')) {
+      const highest = Math.max(...(keys as number[]).filter(Number.isFinite));
+      return ((Number.isFinite(highest) ? highest : 0) + 1) as T[K];
+    }
+
+    if (keys.every((value) => typeof value === 'string')) {
+      const strings = keys as string[];
+      if (strings.every((value) => DIGITS_ONLY.test(value))) {
+        const highest = Math.max(...strings.map(Number));
+        return String(highest + 1) as T[K];
+      }
+      return randomUuid() as T[K];
+    }
+
+    throw new Error(
+      `Cannot derive the next id for "${String(key)}": existing keys are neither all numbers nor all strings. ` +
+        'Supply an explicit `generateId` to the data source.',
+    );
+  };
+};
+
+export { randomUuid };

--- a/lib/core/inMemoryQuery.test.ts
+++ b/lib/core/inMemoryQuery.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+
+import { filterRecords, paginateRecords, queryRecords, sortRecords } from './inMemoryQuery';
+
+interface Row { id: number; name: string; age?: number; active: boolean }
+
+const rows: Row[] = [
+  { id: 1, name: 'Alice', age: 30, active: true },
+  { id: 2, name: 'bob', age: 25, active: false },
+  { id: 3, name: 'Carol', active: true },
+  { id: 4, name: 'Dave', age: 25, active: false },
+];
+
+describe('filterRecords', () => {
+  it('matches case-insensitive substrings', () => {
+    expect(filterRecords(rows, { name: 'bo' }).map((r) => r.id)).toEqual([2]);
+    expect(filterRecords(rows, { name: 'A' }).map((r) => r.id)).toEqual([1, 3, 4]);
+  });
+
+  it('ignores empty, null and undefined filter values', () => {
+    expect(filterRecords(rows, { name: '' })).toHaveLength(4);
+    expect(filterRecords(rows, { name: undefined })).toHaveLength(4);
+  });
+
+  it('excludes records missing the filtered field', () => {
+    expect(filterRecords(rows, { age: 25 }).map((r) => r.id)).toEqual([2, 4]);
+    expect(filterRecords(rows, { age: 3 }).map((r) => r.id)).not.toContain(3);
+  });
+
+  it('combines multiple filters conjunctively', () => {
+    expect(filterRecords(rows, { age: 25, name: 'bob' }).map((r) => r.id)).toEqual([2]);
+  });
+});
+
+describe('sortRecords', () => {
+  it('orders numerically rather than lexicographically', () => {
+    const data = [{ n: 10 }, { n: 9 }, { n: 100 }];
+    expect(sortRecords(data, [{ field: 'n', direction: 'ascend' }]).map((r) => r.n)).toEqual([9, 10, 100]);
+  });
+
+  it('reverses for descend', () => {
+    expect(sortRecords(rows, [{ field: 'id', direction: 'descend' }]).map((r) => r.id)).toEqual([4, 3, 2, 1]);
+  });
+
+  it('places missing values last in both directions', () => {
+    expect(sortRecords(rows, [{ field: 'age', direction: 'ascend' }]).at(-1)?.id).toBe(3);
+    expect(sortRecords(rows, [{ field: 'age', direction: 'descend' }]).at(-1)?.id).toBe(3);
+  });
+
+  it('breaks ties with later sort entries', () => {
+    const sorted = sortRecords(rows, [
+      { field: 'age', direction: 'ascend' },
+      { field: 'name', direction: 'descend' },
+    ]);
+    // ids 2 and 4 both share age 25, so the name breaks the tie
+    expect(sorted.slice(0, 2).map((r) => r.id)).toEqual([4, 2]);
+  });
+
+  it('collates strings by locale, so case does not dominate ordering', () => {
+    // A raw `>` comparison orders by char code, putting every capitalised name
+    // ahead of every lowercase one ('D' is 68, 'b' is 98). Locale collation
+    // gives the alphabetical order a reader expects.
+    const data = [{ name: 'Dave' }, { name: 'bob' }, { name: 'Alice' }];
+    expect(sortRecords(data, [{ field: 'name', direction: 'ascend' }]).map((r) => r.name)).toEqual([
+      'Alice',
+      'bob',
+      'Dave',
+    ]);
+  });
+
+  it('does not mutate the input', () => {
+    const original = [...rows];
+    sortRecords(rows, [{ field: 'id', direction: 'descend' }]);
+    expect(rows).toEqual(original);
+  });
+});
+
+describe('paginateRecords', () => {
+  it('slices 1-based pages', () => {
+    expect(paginateRecords(rows, 1, 2).map((r) => r.id)).toEqual([1, 2]);
+    expect(paginateRecords(rows, 2, 2).map((r) => r.id)).toEqual([3, 4]);
+  });
+
+  it('returns empty for pages past the end', () => {
+    expect(paginateRecords(rows, 9, 2)).toEqual([]);
+  });
+});
+
+describe('queryRecords', () => {
+  it('filters before counting the total, and paginates after', () => {
+    const page = queryRecords(rows, {
+      page: 1,
+      pageSize: 1,
+      filters: { active: true },
+      sort: [{ field: 'id', direction: 'descend' }],
+    });
+    expect(page.items.map((r) => r.id)).toEqual([3]);
+    // total reflects everything matching the filter, not the page size
+    expect(page.total).toBe(2);
+  });
+});

--- a/lib/core/inMemoryQuery.ts
+++ b/lib/core/inMemoryQuery.ts
@@ -1,0 +1,89 @@
+import type { CrudFilters, CrudPage, CrudQuery, CrudSort } from './types';
+
+/**
+ * Ordering for values of unknown-at-compile-time shape.
+ *
+ * Numbers, booleans and dates compare by magnitude; everything else compares
+ * as a locale-aware string, so `'b'` sorts after `'a'` and `'10'` after `'9'`
+ * numerically where both are digit strings.
+ */
+const compareValues = (a: unknown, b: unknown): number => {
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  if (typeof a === 'boolean' && typeof b === 'boolean') return Number(a) - Number(b);
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  return String(a).localeCompare(String(b), undefined, { numeric: true });
+};
+
+/** Case-insensitive substring match, the behaviour the table's search box implies. */
+const matchesFilter = (value: unknown, filter: unknown): boolean => {
+  if (value === undefined || value === null) return false;
+  return String(value).toLowerCase().includes(String(filter).toLowerCase());
+};
+
+/**
+ * Apply filters to an in-memory collection.
+ *
+ * Filters whose value is undefined, null or the empty string are ignored, so
+ * a cleared search box does not exclude everything. A record missing the
+ * filtered field never matches.
+ */
+export const filterRecords = <T>(records: readonly T[], filters?: CrudFilters<T>): readonly T[] => {
+  if (!filters) return records;
+
+  const active = Object.entries(filters).filter(
+    ([, value]) => value !== undefined && value !== null && value !== '',
+  );
+  if (active.length === 0) return records;
+
+  return records.filter((record) =>
+    active.every(([field, value]) => matchesFilter(record[field as keyof T], value)),
+  );
+};
+
+/**
+ * Apply an ordered list of sort instructions.
+ *
+ * Earlier entries take precedence; later ones break ties. Missing values sort
+ * last in both directions - they carry no ordering information, so surfacing
+ * them ahead of real data in one direction would be arbitrary.
+ */
+export const sortRecords = <T>(records: readonly T[], sort?: readonly CrudSort<T>[]): readonly T[] => {
+  if (!sort || sort.length === 0) return records;
+
+  return [...records].sort((a, b) => {
+    for (const { field, direction } of sort) {
+      const left = a[field];
+      const right = b[field];
+
+      const leftMissing = left === undefined || left === null;
+      const rightMissing = right === undefined || right === null;
+      if (leftMissing && rightMissing) continue;
+      if (leftMissing) return 1;
+      if (rightMissing) return -1;
+
+      const comparison = compareValues(left, right);
+      if (comparison !== 0) return direction === 'ascend' ? comparison : -comparison;
+    }
+    return 0;
+  });
+};
+
+/** Take the requested page. Pages are 1-based; out-of-range pages yield an empty slice. */
+export const paginateRecords = <T>(records: readonly T[], page: number, pageSize: number): readonly T[] => {
+  const start = Math.max(0, (page - 1) * pageSize);
+  return records.slice(start, start + pageSize);
+};
+
+/**
+ * The shared filter-then-sort-then-paginate pipeline.
+ *
+ * Every strategy backed by a local collection routes through this, so their
+ * querying behaviour cannot drift apart.
+ */
+export const queryRecords = <T>(records: readonly T[], query: CrudQuery<T>): CrudPage<T> => {
+  const matched = sortRecords(filterRecords(records, query.filters), query.sort);
+  return {
+    items: paginateRecords(matched, query.page, query.pageSize),
+    total: matched.length,
+  };
+};

--- a/lib/core/index.ts
+++ b/lib/core/index.ts
@@ -1,0 +1,28 @@
+export type {
+  CrudDataSource,
+  CrudDraft,
+  CrudFilters,
+  CrudFilterValue,
+  CrudPage,
+  CrudQuery,
+  CrudSort,
+  IdGenerator,
+  SortDirection,
+} from './types';
+
+export { defaultIdGenerator, randomUuid } from './identity';
+export { filterRecords, paginateRecords, queryRecords, sortRecords } from './inMemoryQuery';
+
+export { InMemoryDataSource } from './InMemoryDataSource';
+export { StaticDataSource } from './StaticDataSource';
+export { LocalStorageDataSource } from './LocalStorageDataSource';
+export type { Timestamped } from './LocalStorageDataSource';
+export { RestDataSource, RestError } from './RestDataSource';
+export type {
+  RestDataSourceOptions,
+  RestEndpoints,
+  RestMethods,
+  RestParamNames,
+} from './RestDataSource';
+export { CustomDataSource, UnsupportedOperationError } from './CustomDataSource';
+export type { CrudOperations } from './CustomDataSource';

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -1,0 +1,92 @@
+/**
+ * The core data-access contract every CRUD strategy implements.
+ *
+ * `T` is the record shape and `K` the property holding its identity, so
+ * `T[K]` is the precise type of an id throughout - never `any`, never a
+ * widened `string | number`.
+ */
+
+/** Sort direction, matching the vocabulary ProTable reports. */
+export type SortDirection = 'ascend' | 'descend';
+
+/** One sort instruction. Queries carry an ordered list to support multi-sort. */
+export interface CrudSort<T> {
+  readonly field: keyof T;
+  readonly direction: SortDirection;
+}
+
+/**
+ * A value a column can be filtered by.
+ *
+ * Deliberately narrow: filters arrive from form inputs and query strings, so
+ * this is the complete set of things a user can actually express. Anything
+ * richer belongs in a custom data source.
+ */
+export type CrudFilterValue = string | number | boolean;
+
+/** Field-keyed filters. Absent keys are unfiltered. */
+export type CrudFilters<T> = {
+  readonly [P in keyof T]?: CrudFilterValue;
+};
+
+/** A complete read request: which slice, in what order, matching what. */
+export interface CrudQuery<T> {
+  /** 1-based, matching ProTable's `current`. */
+  readonly page: number;
+  readonly pageSize: number;
+  readonly sort?: readonly CrudSort<T>[];
+  readonly filters?: CrudFilters<T>;
+}
+
+/** One page of results plus the total matching the filters (not the page size). */
+export interface CrudPage<T> {
+  readonly items: readonly T[];
+  readonly total: number;
+}
+
+/**
+ * A record being written.
+ *
+ * Partial because the identity is assigned by the source on create, and an
+ * update legitimately touches a subset of fields.
+ */
+export type CrudDraft<T> = Partial<T>;
+
+/**
+ * Produces the identity for a newly created record.
+ *
+ * Receives the existing records so a strategy can derive the next value
+ * (max + 1, a fresh UUID, a sequence). Supplying one replaces the built-in
+ * policy entirely.
+ */
+export type IdGenerator<T, K extends keyof T> = (existing: readonly T[]) => T[K];
+
+/**
+ * The interface every strategy implements: static fixtures, REST,
+ * localStorage, or a consumer's own.
+ *
+ * Implementations own their storage and lifetime. They are plain objects -
+ * no React involvement - so each is unit-testable without a renderer.
+ */
+export interface CrudDataSource<T, K extends keyof T> {
+  /** Read one page. Implementations must apply filters before paginating. */
+  list(query: CrudQuery<T>): Promise<CrudPage<T>>;
+
+  /** Persist a new record and return it as stored, identity included. */
+  create(draft: CrudDraft<T>): Promise<T>;
+
+  /** Merge `draft` into the record at `id` and return the stored result. */
+  update(id: T[K], draft: CrudDraft<T>): Promise<T>;
+
+  /** Delete the record at `id`. */
+  remove(id: T[K]): Promise<void>;
+
+  /**
+   * Every record matching the query, ignoring pagination.
+   *
+   * Exists so export can cover the whole result set rather than the current
+   * page. Optional: a source over an unbounded remote collection may have no
+   * safe way to honour it, and callers must degrade to `list` when absent.
+   */
+  listAll?(query: Omit<CrudQuery<T>, 'page' | 'pageSize'>): Promise<readonly T[]>;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,10 +20,10 @@ export default defineConfig({
       // time coverage was introduced. Raise them as suites land (#29) so a
       // regression fails the run; never lower them to make a build pass.
       thresholds: {
-        statements: 42,
-        branches: 34,
-        functions: 31,
-        lines: 42,
+        statements: 56,
+        branches: 48,
+        functions: 46,
+        lines: 55,
       },
     },
   },


### PR DESCRIPTION
Refs #23. Also lays the groundwork that resolves #26 and #27 — those close when the hook is migrated onto this in the follow-up.

**Additive only.** Nothing is wired into `useCrudTable` or `CrudTable` yet, so this ships with zero behaviour change. Splitting it this way keeps the breaking migration reviewable on its own.

## What was wrong

The four strategies were closure-based factory functions selected by a `useMemo`. Their working state lived in a closure keyed on caller-argument identity, which caused two distinct problems:

- an inline `staticData` literal discarded every created row whenever the parent re-rendered (#26)
- no strategy could be exercised without mounting a component

## Structure

```
CrudDataSource<T, K>          interface — list / create / update / remove / listAll?
├── InMemoryDataSource        abstract; owns query, identity, mutation semantics
│   ├── StaticDataSource      seeds a copy into instance state
│   └── LocalStorageDataSource  read/write through storage, timestamps
├── RestDataSource            protected url/payload seams
└── CustomDataSource          adapts consumer-supplied operations
```

`T[K]` is the id type throughout — no `any`, no widened `string | number`.

The abstract base is what stops the static and localStorage strategies drifting apart: subclasses supply only `read`/`write`, and every other semantic is defined once.

## Identity generation (#27)

The old code did `Number(item[key]) || 0`. For a UUID that is `NaN`, `|| 0` collapses it to `0`, and **every created row came back as id `1`** — duplicate keys, with `update` and `remove` then resolving to the wrong record. Silent data corruption.

The replacement branches on the runtime type of existing keys rather than coercing:

| Existing keys | Next id |
|---|---|
| numbers | highest + 1 |
| digit-like strings | highest + 1, kept a string |
| other strings | fresh UUID |
| empty | `1` (previous behaviour) |
| mixed types | throws — cannot be continued safely |

Throwing on mixed keys is deliberate. Guessing there is how the original bug behaved.

## Details worth flagging

**`update` never takes the identity from the draft.** Letting a write move a record's key would orphan it from the id the caller is updating. Pinned by a test.

**localStorage reads degrade, writes throw.** An unreadable or malformed cache falls back to the seed rather than taking the table down. A *failed write* throws — telling the user a save succeeded when nothing persisted is worse than an error.

**`RestError` carries `status` and `body`,** so a consumer can branch on a 409 or surface a validation payload instead of receiving a flattened string.

**Sorting now collates by locale.** The old raw `>` comparison ordered by char code, putting every capitalised name ahead of every lowercase one. There's a test pinning `['Alice', 'bob', 'Dave']`.

**`listAll` is optional on the interface** — a source over an unbounded remote collection has no safe way to honour it, and callers must degrade. It's what #28 will use for full-dataset export.

## Tests

58 new tests, every source exercised as a plain object with no renderer. `RestDataSource` takes an injected `fetchImpl`, so its suite covers envelope shapes, error propagation, param renaming, id encoding, 204 bodies and subclass extension — all without network.

Coverage **42.5% → 56.25%** statements; `lib/core` at 89.81%. Thresholds ratcheted to match.

## Verification

```
pnpm lint       0 errors
pnpm test       102 passed (was 44)
pnpm build:lib  ok
```

One incidental config change: `no-unused-vars` gets an `argsIgnorePattern: '^_'`. Overridable base methods must keep their full parameter list for subclass overrides to stay type-compatible, even where the base implementation ignores them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>