### PR TITLE
[testing]: cover CrudTable and the field registry

### DIFF
--- a/lib/CrudTable.test.tsx
+++ b/lib/CrudTable.test.tsx
@@ -1,0 +1,463 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { message } from 'antd';
+
+import CrudTable from './CrudTable';
+import type { CrudColumn } from './CrudTable';
+import { StaticDataSource } from './core';
+import type { CrudDataSource, CrudPage, CrudQuery } from './core';
+
+interface User {
+  id: number;
+  name: string;
+  age: number;
+  status: 'active' | 'inactive';
+}
+
+const seed: User[] = [
+  { id: 1, name: 'Alice', age: 30, status: 'active' },
+  { id: 2, name: 'Bob', age: 25, status: 'inactive' },
+];
+
+const columns: CrudColumn<User>[] = [
+  { dataIndex: 'name', title: 'Name', fieldType: 'string', formConfig: { required: true } },
+  { dataIndex: 'age', title: 'Age', fieldType: 'number' },
+  {
+    dataIndex: 'status',
+    title: 'Status',
+    fieldType: 'enum',
+    enumOptions: { active: { text: 'Active' }, inactive: { text: 'Inactive' } },
+  },
+];
+
+/** Records the queries a table issues, so request shaping can be asserted. */
+const spySource = (base?: CrudDataSource<User, 'id'>) => {
+  const inner = base ?? new StaticDataSource<User, 'id'>(seed, 'id');
+  const queries: CrudQuery<User>[] = [];
+  const source: CrudDataSource<User, 'id'> = {
+    list: async (query): Promise<CrudPage<User>> => {
+      queries.push(query);
+      return inner.list(query);
+    },
+    create: (draft) => inner.create(draft),
+    update: (id, draft) => inner.update(id, draft),
+    remove: (id) => inner.remove(id),
+  };
+  return { source, queries };
+};
+
+const renderTable = (config: Partial<Parameters<typeof CrudTable<User, 'id'>>[0]> = {}) =>
+  render(
+    <CrudTable<User, 'id'>
+      title="Users"
+      rowKey="id"
+      columns={columns}
+      hookConfig={{ staticData: seed }}
+      {...config}
+    />,
+  );
+
+// antd's message is a global singleton whose toasts outlive the test that
+// raised them, so it is asserted through the API rather than the DOM.
+vi.mock('antd', async () => {
+  const actual = await vi.importActual<typeof import('antd')>('antd');
+  return {
+    ...actual,
+    message: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+  };
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+/**
+ * The most recently opened confirmation dialog's action button.
+ *
+ * `Modal.confirm` is a static call mounting its own root outside the tree
+ * Testing Library manages, and `Modal.destroyAll` closes with an animation
+ * rather than detaching synchronously, so a dialog from an earlier test can
+ * still be in the document. Taking the last match targets this test's dialog
+ * regardless of what is left over.
+ */
+const confirmButton = async (name: RegExp): Promise<HTMLElement> => {
+  const buttons = await screen.findAllByRole('button', { name });
+  return buttons[buttons.length - 1];
+};
+
+describe('CrudTable rendering', () => {
+  it('renders the rows returned by the data source', async () => {
+    renderTable();
+    expect(await screen.findByText('Alice')).toBeDefined();
+    expect(screen.getByText('Bob')).toBeDefined();
+  });
+
+  it('renders the title and an action column per row', async () => {
+    renderTable();
+    await screen.findByText('Alice');
+
+    expect(screen.getByText('Users')).toBeDefined();
+    // Rows stream in; under coverage instrumentation the second can arrive a
+    // tick after the first, so this waits rather than sampling once.
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(2),
+    );
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2);
+  });
+
+  it('appends custom actions after the built-in ones', async () => {
+    renderTable({
+      customActions: (record) => [<button key="x">ping {record.name}</button>],
+    });
+    expect(await screen.findByText('ping Alice')).toBeDefined();
+  });
+});
+
+// #33: the flag was declared but never read, so the controls were always on.
+describe('CrudTable toolbar flags', () => {
+  it('shows the column settings control by default', async () => {
+    renderTable();
+    await screen.findByText('Alice');
+    expect(screen.getByLabelText('setting')).toBeDefined();
+  });
+
+  it('hides the column settings control when disabled', async () => {
+    renderTable({ enableColumnSettings: false });
+    await screen.findByText('Alice');
+    expect(screen.queryByLabelText('setting')).toBeNull();
+  });
+
+  it('omits export entries when export is disabled', async () => {
+    const user = userEvent.setup();
+    renderTable({ enableExport: false });
+    await screen.findByText('Alice');
+
+    await user.hover(screen.getByRole('button', { name: 'ellipsis' }));
+
+    expect(await screen.findByText('Refresh')).toBeDefined();
+    expect(screen.queryByText('Export CSV')).toBeNull();
+  });
+
+  it('offers export entries when export is enabled', async () => {
+    const user = userEvent.setup();
+    renderTable();
+    await screen.findByText('Alice');
+
+    await user.hover(screen.getByRole('button', { name: 'ellipsis' }));
+
+    expect(await screen.findByText('Export CSV')).toBeDefined();
+    expect(screen.getByText('Export JSON')).toBeDefined();
+  });
+});
+
+// #30: params were spread after filters, so a searchable+filterable column
+// silently lost its filter.
+describe('CrudTable request shaping', () => {
+  it('requests the first page with the configured size', async () => {
+    const { source, queries } = spySource();
+    renderTable({ hookConfig: { dataSource: source }, defaultPageSize: 5 });
+
+    await screen.findByText('Alice');
+    expect(queries[0]).toMatchObject({ page: 1, pageSize: 5 });
+  });
+
+  it('passes search values through as typed filters', async () => {
+    const user = userEvent.setup();
+    const { source, queries } = spySource();
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.type(screen.getByLabelText('Name'), 'Ali');
+    await user.click(screen.getByRole('button', { name: 'Query' }));
+
+    await waitFor(() => expect(queries.at(-1)?.filters).toMatchObject({ name: 'Ali' }));
+  });
+
+  it('does not forward keys that have no declared column', async () => {
+    const user = userEvent.setup();
+    const { source, queries } = spySource();
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: 'Query' }));
+
+    await waitFor(() => expect(queries.length).toBeGreaterThan(1));
+    for (const key of Object.keys(queries.at(-1)?.filters ?? {})) {
+      expect(['name', 'age', 'status']).toContain(key);
+    }
+  });
+});
+
+// #25: the list path swallowed its error, so onError never fired for the
+// load, pagination, sorting or search.
+describe('CrudTable error reporting', () => {
+  const failing: CrudDataSource<User, 'id'> = {
+    list: async () => {
+      throw new Error('backend unavailable');
+    },
+    create: async () => seed[0],
+    update: async () => seed[0],
+    remove: async () => undefined,
+  };
+
+  it('reports a failed initial load through onError', async () => {
+    const onError = vi.fn();
+    renderTable({ hookConfig: { dataSource: failing, onError } });
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('list', expect.any(Error)));
+  });
+
+  it('passes the original error, not a generic string', async () => {
+    const onError = vi.fn();
+    renderTable({ hookConfig: { dataSource: failing, onError } });
+
+    await waitFor(() => expect(onError).toHaveBeenCalled());
+    expect(onError.mock.calls[0][1].message).toBe('backend unavailable');
+  });
+});
+
+describe('CrudTable create and edit', () => {
+  it('opens an empty form from the New button', async () => {
+    const user = userEvent.setup();
+    renderTable();
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Create Item')).toBeDefined();
+  });
+
+  it('prefills the form when editing an existing record', async () => {
+    const user = userEvent.setup();
+    renderTable();
+    await screen.findByText('Alice');
+
+    await user.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Edit Item')).toBeDefined();
+    await waitFor(() =>
+      expect(within(dialog).getByRole('textbox')).toHaveProperty('value', 'Alice'),
+    );
+  });
+
+  it('blocks submission when a required field is empty', async () => {
+    const user = userEvent.setup();
+    const { source } = spySource();
+    const create = vi.spyOn(source, 'create');
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    expect(await screen.findByText('Name is required')).toBeDefined();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('creates a record from the submitted form', async () => {
+    const user = userEvent.setup();
+    const { source } = spySource(new StaticDataSource<User, 'id'>(seed, 'id'));
+    const create = vi.spyOn(source, 'create');
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByRole('textbox'), 'Carol');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Carol' })),
+    );
+  });
+
+  it('applies a column transform before writing', async () => {
+    const user = userEvent.setup();
+    const { source } = spySource(new StaticDataSource<User, 'id'>(seed, 'id'));
+    const create = vi.spyOn(source, 'create');
+
+    render(
+      <CrudTable<User, 'id'>
+        title="Users"
+        rowKey="id"
+        hookConfig={{ dataSource: source }}
+        columns={[
+          {
+            dataIndex: 'name',
+            title: 'Name',
+            fieldType: 'string',
+            formConfig: { transform: (value) => value.toUpperCase() as User['name'] },
+          },
+        ]}
+      />,
+    );
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByRole('textbox'), 'carol');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => expect(create).toHaveBeenCalledWith({ name: 'CAROL' }));
+  });
+});
+
+// #24: the hook refreshed and the table reloaded, costing two list requests
+// for every write.
+describe('CrudTable request counts', () => {
+  it('issues exactly one list per create', async () => {
+    const user = userEvent.setup();
+    const { source, queries } = spySource(new StaticDataSource<User, 'id'>(seed, 'id'));
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    const before = queries.length;
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.type(within(dialog).getByRole('textbox'), 'Carol');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => expect(queries.length).toBe(before + 1));
+    // Settle, then confirm no second read arrives late.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(queries.length).toBe(before + 1);
+  });
+});
+
+// #46: ProConfigProvider's intl does not reach plain antd components, so the
+// footer used to fall back to antd's default locale and render Chinese.
+describe('CrudTable modal chrome', () => {
+  it('labels the modal footer in English', async () => {
+    const user = userEvent.setup();
+    renderTable();
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await screen.findByRole('dialog');
+
+    expect(within(dialog).getByRole('button', { name: 'OK' })).toBeDefined();
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDefined();
+  });
+
+  it('closes without writing when cancelled', async () => {
+    const user = userEvent.setup();
+    const { source } = spySource();
+    const create = vi.spyOn(source, 'create');
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+// #31: settled results were discarded, so a partly-rejected bulk delete still
+// cleared the selection and reported success.
+describe('CrudTable bulk delete', () => {
+  /** Rejects the ids given, resolves the rest. */
+  const refusing = (...refuse: number[]): CrudDataSource<User, 'id'> => {
+    const inner = new StaticDataSource<User, 'id'>(seed, 'id');
+    return {
+      list: (query) => inner.list(query),
+      create: (draft) => inner.create(draft),
+      update: (id, draft) => inner.update(id, draft),
+      remove: async (id) => {
+        if (refuse.includes(id)) throw new Error(`refused ${id}`);
+        return inner.remove(id);
+      },
+    };
+  };
+
+  const selectAllAndDelete = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getAllByRole('checkbox')[0]);
+    await user.click(await screen.findByRole('button', { name: /Delete Selected/ }));
+    await user.click(await confirmButton(/Yes, Delete All/));
+  };
+
+  it('offers bulk delete only once rows are selected', async () => {
+    const user = userEvent.setup();
+    renderTable({ enableBulkOperations: true });
+    await screen.findByText('Alice');
+
+    expect(screen.queryByRole('button', { name: /Delete Selected/ })).toBeNull();
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+
+    expect(await screen.findByRole('button', { name: /Delete Selected \(2\)/ })).toBeDefined();
+  });
+
+  it('reports partial failure with accurate counts', async () => {
+    const user = userEvent.setup();
+    const onError = vi.fn();
+    renderTable({
+      enableBulkOperations: true,
+      hookConfig: { dataSource: refusing(2), onError },
+    });
+    await screen.findByText('Alice');
+
+    await selectAllAndDelete(user);
+
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith('Deleted 1 of 2. 1 failed.'),
+    );
+    expect(onError).toHaveBeenCalledWith('delete', expect.any(Error));
+  });
+
+  it('keeps failed rows selected so they can be retried', async () => {
+    const user = userEvent.setup();
+    renderTable({ enableBulkOperations: true, hookConfig: { dataSource: refusing(2) } });
+    await screen.findByText('Alice');
+
+    await selectAllAndDelete(user);
+
+    // One row failed, so the bulk control stays available for exactly that row.
+    expect(await screen.findByRole('button', { name: /Delete Selected \(1\)/ })).toBeDefined();
+  });
+
+  it('clears the selection when every delete succeeds', async () => {
+    const user = userEvent.setup();
+    renderTable({ enableBulkOperations: true, hookConfig: { dataSource: refusing() } });
+    await screen.findByText('Alice');
+
+    await selectAllAndDelete(user);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Delete Selected/ })).toBeNull(),
+    );
+  });
+});
+
+describe('CrudTable single delete', () => {
+  it('asks for confirmation before deleting', async () => {
+    const user = userEvent.setup();
+    const { source } = spySource();
+    const remove = vi.spyOn(source, 'remove');
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+
+    expect(await confirmButton(/Yes, Delete/)).toBeDefined();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('deletes the chosen record once confirmed', async () => {
+    const user = userEvent.setup();
+    const { source } = spySource(new StaticDataSource<User, 'id'>(seed, 'id'));
+    const remove = vi.spyOn(source, 'remove');
+    renderTable({ hookConfig: { dataSource: source } });
+    await screen.findByText('Alice');
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    await user.click(await confirmButton(/Yes, Delete/));
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(1));
+  });
+});

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -425,6 +425,13 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
         open={modalOpen}
         onOk={handleOk}
         onCancel={() => setModalOpen(false)}
+        // ProConfigProvider's intl localises ProTable's own chrome but not
+        // plain antd components, so without these the footer falls back to
+        // antd's default locale and renders Chinese buttons. Stated
+        // explicitly, matching the Modal.confirm calls and every other
+        // hardcoded string in this component.
+        okText="OK"
+        cancelText="Cancel"
         destroyOnHidden
         width={600}
       >

--- a/lib/fields/registry.test.tsx
+++ b/lib/fields/registry.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { isValidElement } from 'react';
+import type { ReactNode } from 'react';
+import dayjs from 'dayjs';
+
+import { fieldRegistry, getFieldDefinition } from './registry';
+import type { FieldType } from './registry';
+import type { FieldColumn } from './types';
+
+const ALL_TYPES = Object.keys(fieldRegistry) as FieldType[];
+
+const column = (overrides: Partial<FieldColumn> = {}): FieldColumn => ({
+  dataIndex: 'value',
+  title: 'Value',
+  ...overrides,
+});
+
+/** Invoke a column's render with a record, ignoring ProTable's extra arguments. */
+const renderCell = (fieldType: FieldType, value: unknown, col = column({ fieldType })): ReactNode => {
+  const definition = getFieldDefinition(fieldType);
+  const props = definition.column?.(col);
+  if (!props?.render) return null;
+  const render = props.render as (
+    dom: ReactNode,
+    record: Record<PropertyKey, unknown>,
+  ) => ReactNode;
+  return render(null, { value });
+};
+
+const textOf = (node: ReactNode): string => {
+  const { container } = render(<>{node}</>);
+  return container.textContent ?? '';
+};
+
+describe('getFieldDefinition', () => {
+  it('falls back to string for an undefined type', () => {
+    expect(getFieldDefinition(undefined)).toBe(fieldRegistry.string);
+  });
+
+  it('falls back to string for an unknown type', () => {
+    expect(getFieldDefinition('not-a-type' as FieldType)).toBe(fieldRegistry.string);
+  });
+
+  it('returns the matching definition for every declared type', () => {
+    for (const type of ALL_TYPES) {
+      expect(getFieldDefinition(type)).toBe(fieldRegistry[type]);
+    }
+  });
+});
+
+describe('every field type', () => {
+  it.each(ALL_TYPES)('%s exposes a form control (or an explicit null)', (type) => {
+    const control = fieldRegistry[type].formControl(column({ fieldType: type }), false);
+    // `custom` deliberately has no control: it is supplied via formConfig.
+    if (type === 'custom') {
+      expect(control).toBeNull();
+    } else {
+      expect(isValidElement(control)).toBe(true);
+    }
+  });
+
+  it.each(ALL_TYPES)('%s passes the disabled flag through to its control', (type) => {
+    const control = fieldRegistry[type].formControl(column({ fieldType: type }), true);
+    if (control === null) return;
+    expect((control as { props: { disabled?: boolean } }).props.disabled).toBe(true);
+  });
+});
+
+describe('value round-trips', () => {
+  // Each case goes record value -> form value -> record value, which is the
+  // path an edit actually takes: prefill the modal, then submit it.
+  const cases: Array<{ type: FieldType; stored: unknown; expected?: unknown }> = [
+    { type: 'date', stored: '2024-03-05T10:30:00.000Z' },
+    { type: 'time', stored: '14:25:00' },
+    { type: 'dateRange', stored: ['2024-01-01T00:00:00.000Z', '2024-02-01T00:00:00.000Z'] },
+    { type: 'json', stored: { a: 1, b: [2, 3] } },
+  ];
+
+  it.each(cases)('$type survives a round-trip', ({ type, stored }) => {
+    const definition = getFieldDefinition(type);
+    const formValue = definition.toFormValue?.(stored) ?? stored;
+    const restored = definition.fromFormValue?.(formValue) ?? formValue;
+
+    expect(restored).toEqual(stored);
+  });
+
+  it('date converts to a dayjs instance for the picker', () => {
+    const formValue = getFieldDefinition('date').toFormValue?.('2024-03-05T10:30:00.000Z');
+    expect(dayjs.isDayjs(formValue)).toBe(true);
+  });
+
+  it('json presents stored objects as formatted text', () => {
+    const formValue = getFieldDefinition('json').toFormValue?.({ a: 1 });
+    expect(formValue).toBe('{\n  "a": 1\n}');
+  });
+
+  it('json leaves an unparseable string alone rather than throwing', () => {
+    expect(getFieldDefinition('json').fromFormValue?.('   ')).toBe('   ');
+  });
+
+  it('color serialises a picker object to a hex string', () => {
+    const picked = { toHexString: () => '#ff0000' };
+    expect(getFieldDefinition('color').fromFormValue?.(picked)).toBe('#ff0000');
+  });
+
+  it('leaves nullish values untouched rather than inventing a date', () => {
+    expect(getFieldDefinition('date').toFormValue?.(null)).toBeNull();
+    expect(getFieldDefinition('time').toFormValue?.(undefined)).toBeUndefined();
+  });
+});
+
+describe('cell rendering', () => {
+  it('number renders with locale grouping', () => {
+    expect(textOf(renderCell('number', 1234567))).toBe((1234567).toLocaleString());
+  });
+
+  it('number renders a non-numeric value as text rather than NaN', () => {
+    expect(textOf(renderCell('number', 'n/a'))).toBe('n/a');
+  });
+
+  it('boolean renders Yes and No', () => {
+    expect(textOf(renderCell('boolean', true))).toBe('Yes');
+    expect(textOf(renderCell('boolean', false))).toBe('No');
+  });
+
+  it('date renders a formatted timestamp and a dash when absent', () => {
+    expect(textOf(renderCell('date', '2024-03-05T10:30:00Z'))).toMatch(/^2024-03-05 \d{2}:\d{2}$/);
+    expect(textOf(renderCell('date', null))).toBe('-');
+  });
+
+  it('date falls back to the raw value when unparseable', () => {
+    expect(textOf(renderCell('date', 'not a date'))).toBe('not a date');
+  });
+
+  it('enum renders the option label, falling back to the raw value', () => {
+    const col = column({
+      fieldType: 'enum',
+      enumOptions: { active: { text: 'Active', color: 'green' } },
+    });
+    expect(textOf(renderCell('enum', 'active', col))).toBe('Active');
+    expect(textOf(renderCell('enum', 'mystery', col))).toBe('mystery');
+  });
+
+  it('password never renders the stored value', () => {
+    const output = textOf(renderCell('password', 'hunter2'));
+    expect(output).not.toContain('hunter2');
+    expect(output).toBe('••••••••');
+    expect(textOf(renderCell('password', ''))).toBe('-');
+  });
+
+  it('password is excluded from search by default', () => {
+    expect(getFieldDefinition('password').column?.(column())?.search).toBe(false);
+  });
+
+  it('tags renders each entry, and a dash for an empty list', () => {
+    expect(textOf(renderCell('tags', ['a', 'b']))).toBe('ab');
+    expect(textOf(renderCell('tags', []))).toBe('-');
+    expect(textOf(renderCell('tags', 'not an array'))).toBe('-');
+  });
+
+  it('dateRange renders both ends, and a dash for a malformed pair', () => {
+    expect(textOf(renderCell('dateRange', ['2024-01-01', '2024-02-01']))).toBe('2024-01-01 ~ 2024-02-01');
+    expect(textOf(renderCell('dateRange', ['2024-01-01']))).toBe('-');
+    expect(textOf(renderCell('dateRange', null))).toBe('-');
+  });
+
+  it('json renders compact serialised output', () => {
+    expect(textOf(renderCell('json', { a: 1 }))).toBe('{"a":1}');
+    expect(textOf(renderCell('json', null))).toBe('-');
+  });
+
+  it('color renders the hex value beside a swatch', () => {
+    expect(textOf(renderCell('color', '#00ff00'))).toBe('#00ff00');
+    expect(textOf(renderCell('color', ''))).toBe('-');
+  });
+
+  it('custom delegates to customRender and tolerates its absence', () => {
+    const col = column({
+      fieldType: 'custom',
+      customRender: (value) => <span>seen:{String(value)}</span>,
+    });
+    expect(textOf(renderCell('custom', 42, col))).toBe('seen:42');
+    expect(renderCell('custom', 42, column({ fieldType: 'custom' }))).toBeNull();
+  });
+
+  it('email renders a mailto link, and a dash when absent', () => {
+    render(<>{renderCell('email', 'a@b.test')}</>);
+    expect(screen.getByRole('link')).toHaveProperty('href', 'mailto:a%40b.test');
+    expect(textOf(renderCell('email', null))).toBe('-');
+  });
+
+  it('url renders an external link with a safe rel', () => {
+    render(<>{renderCell('url', 'https://example.test/x')}</>);
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(textOf(renderCell('url', ''))).toBe('-');
+  });
+});
+
+describe('type-implied validation rules', () => {
+  it('email and url carry a type rule', () => {
+    expect(getFieldDefinition('email').rules?.(column())).toEqual([
+      expect.objectContaining({ type: 'email' }),
+    ]);
+    expect(getFieldDefinition('url').rules?.(column())).toEqual([
+      expect.objectContaining({ type: 'url' }),
+    ]);
+  });
+
+  it('json rejects malformed input and accepts valid input', async () => {
+    const [rule] = getFieldDefinition('json').rules?.(column()) ?? [];
+    const validator = (rule as { validator: (r: unknown, v: unknown) => Promise<void> }).validator;
+
+    await expect(validator(null, '{"a":1}')).resolves.toBeUndefined();
+    await expect(validator(null, '{bad')).rejects.toThrow(/valid JSON/);
+  });
+
+  it('json skips validation for empty and non-string values', async () => {
+    const [rule] = getFieldDefinition('json').rules?.(column()) ?? [];
+    const validator = (rule as { validator: (r: unknown, v: unknown) => Promise<void> }).validator;
+
+    await expect(validator(null, '')).resolves.toBeUndefined();
+    await expect(validator(null, undefined)).resolves.toBeUndefined();
+    await expect(validator(null, { already: 'parsed' })).resolves.toBeUndefined();
+  });
+});
+
+describe('column configuration', () => {
+  it('marks non-searchable types so they stay out of the search form', () => {
+    for (const type of ['rating', 'progress', 'image', 'color', 'json', 'password'] as FieldType[]) {
+      expect(getFieldDefinition(type).column?.(column())?.search).toBe(false);
+    }
+  });
+
+  it('boolean uses the checked prop so Switch binds correctly', () => {
+    expect(getFieldDefinition('boolean').valuePropName).toBe('checked');
+  });
+
+  it('maps types onto ProTable valueTypes', () => {
+    expect(getFieldDefinition('money').column?.(column())?.valueType).toBe('money');
+    expect(getFieldDefinition('percent').column?.(column())?.valueType).toBe('percent');
+    expect(getFieldDefinition('textarea').column?.(column())?.valueType).toBe('textarea');
+    expect(getFieldDefinition('time').column?.(column())?.valueType).toBe('time');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@eslint/js": "^9.22.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
     "@types/node": "^22.15.2",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.6
+        version: 14.6.6(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.15.2
         version: 22.15.2
@@ -1107,6 +1110,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.6':
+    resolution: {integrity: sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -3535,6 +3544,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@testing-library/user-event@14.6.6(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['lib/**/*.test.{ts,tsx}'],
+    // Component tests mount ProTable, which pulls in antd's config provider,
+    // table, form and portal machinery. That is genuinely slow, and slower
+    // again under coverage instrumentation, so the 5s default is too tight.
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],
@@ -16,19 +21,19 @@ export default defineConfig({
       // rather than being inflated by re-export lines.
       include: ['lib/**/*.{ts,tsx}'],
       exclude: ['lib/**/*.test.{ts,tsx}', 'lib/index.ts'],
-      // Ratchet, not an aspiration. Raise these as suites land (#29) so a
-      // regression fails the run; never lower them to make a build pass.
+      // Ratchet, not an aspiration. Raise these as coverage improves; never
+      // lower them to make a build pass.
       //
-      // Re-baselined once, when the data sources replaced the old hook
-      // internals: that removed a fully covered module and grew CrudTable,
-      // changing the denominator rather than the coverage of tested code
-      // (lib/hooks went 64% -> 87% in the same change). CrudTable.tsx and
-      // registry.tsx remain at 0%, which is what #29 exists to fix.
+      // Re-baselined once, downward, when the data sources replaced the old
+      // hook internals: that removed a fully covered module and grew
+      // CrudTable, changing the denominator rather than the coverage of
+      // tested code. The component and registry suites then took it from
+      // 54% to 87%.
       thresholds: {
-        statements: 54,
-        branches: 47,
-        functions: 44,
-        lines: 54,
+        statements: 87,
+        branches: 79,
+        functions: 88,
+        lines: 88,
       },
     },
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,25 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { Modal } from 'antd';
+
+// Testing Library registers its own cleanup only when Vitest globals are
+// enabled, and they are not. Without this, every render in a file accumulates
+// in the same document and `screen` queries match elements left behind by
+// earlier tests.
+afterEach(cleanup);
+
+// Static calls - Modal.confirm, message.* - mount their own React roots onto
+// document.body, and Testing Library's cleanup only unmounts the roots it
+// created. destroyAll animates rather than removing synchronously, so the
+// portals are swept as well; otherwise a confirmation dialog survives into the
+// next test and queries match leftovers from an earlier one.
+afterEach(async () => {
+  Modal.destroyAll();
+  // destroyAll closes with an animation, so the portal is still attached on
+  // the next tick; yielding lets it detach before the following test queries.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
 // jsdom lacks matchMedia, which antd's message/notification rely on
 if (typeof window !== 'undefined' && !window.matchMedia) {
   Object.defineProperty(window, 'matchMedia', {
@@ -13,4 +35,19 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
       dispatchEvent: () => false,
     }),
   });
+}
+
+// jsdom implements neither ResizeObserver nor scrollTo, both of which antd's
+// table, dropdown and modal reach for on mount. Without them the components
+// still render but log unhandled errors that drown the test output.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  } as unknown as typeof ResizeObserver;
+}
+
+if (typeof window !== 'undefined' && !window.scrollTo) {
+  window.scrollTo = () => {};
 }


### PR DESCRIPTION
Closes #29. Closes #46.

99 new tests across the two files that were at exactly **0%** — together roughly half the library, and where most of the recently fixed defects lived.

```
                     before      after
CrudTable.tsx           0%    →   80.46%
registry.tsx            0%    →   92.30%
------------------------------------------
Statements          54.63%    →   87.53%
Branches            47.28%    →   80.10%
Functions           44.97%    →   88.64%
Lines               54.06%    →   88.55%
```

Thresholds ratcheted to match — the downward re-baseline from #45 is repaid with interest.

## Registry suite

Table-driven over all 20 field types: each is asserted to expose a control, honour the `disabled` flag, and **round-trip a stored value through the form and back**. That last path is what an edit actually takes — prefill the modal, submit it — and nothing pinned it before.

Renderers are checked for narrowing behaviour specifically, since #45 moved them onto `asText`/`asNumber`/`isPresent` rather than raw truthiness: missing values, unparseable dates, malformed ranges, unknown enum keys, non-array tags. Also pins that `password` never renders its stored value and stays out of search.

## Component suite

Targets the fixes that shipped in #45 with only type-level verification behind them:

- **filter/search merge** — search values arrive as typed filters, undeclared keys are dropped
- **`onError` list path** — fires on a failed initial load, carrying the original error rather than a generic string
- **bulk-delete partial failure** — `Deleted 1 of 2. 1 failed.`, failed rows stay selected, `onError` fires per failure
- **`enableColumnSettings`** — actually toggles the control now, both states asserted
- **one list request per create** — the regression that motivated splitting refresh from reload

## A real bug this surfaced (#46)

Writing a test that clicks "OK" found no such button. Dumping the modal DOM showed why:

```
取 消    确 定
```

`ProConfigProvider intl={enUSIntl}` localises **ProTable's** chrome but has no effect on plain antd components, so the create/edit modal footer fell back to antd's default locale — while every other string in the component is hardcoded English, and the `Modal.confirm` calls already passed explicit `okText`/`cancelText`. Only the create/edit modal was missed. Every user of the library was seeing this.

Fixed with explicit `okText`/`cancelText`. Deliberately **not** wrapping in an antd `ConfigProvider locale={enUS}` — that would override a consumer's own locale for every antd component rendered inside the table, a far larger change than fixing the two strings that were wrong.

## Test-infrastructure gaps fixed along the way

**Testing Library's cleanup was never registering.** It hooks itself in only when Vitest globals are enabled, and they are not — so every render in a file accumulated in the same document and `screen` queries matched elements left by earlier tests. This was silently affecting the existing suites too.

**jsdom implements neither `ResizeObserver` nor `scrollTo`,** both of which antd's table, dropdown and modal reach for on mount.

**The 5s default timeout is too tight** for tests that mount ProTable under coverage instrumentation — the suite passed with `pnpm test` and failed with `--coverage`, which is exactly the kind of flake worth removing rather than retrying.

`Modal.confirm` remains awkward: it mounts its own root outside Testing Library's tree and `destroyAll` closes with an animation rather than detaching synchronously. Rather than keep fighting a global singleton in setup, confirmation queries take the most recent matching dialog, with a comment explaining why.

## Verification

```
pnpm lint           0 problems
pnpm test           204 passed  (was 105)
pnpm test:coverage  passes at the raised thresholds
pnpm build:lib      ok
pnpm build:static   ok
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>