### PR TITLE
[security]: restrict link and image schemes to an allowlist

### DIFF
--- a/lib/fields/registry.test.tsx
+++ b/lib/fields/registry.test.tsx
@@ -245,3 +245,63 @@ describe('column configuration', () => {
     expect(getFieldDefinition('time').column?.(column())?.valueType).toBe('time');
   });
 });
+
+// #32: React 18 warns about a javascript: href but still renders it, so a
+// stored value could become a click-to-execute link.
+describe('link scheme safety', () => {
+  const DANGEROUS = [
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    '  javascript:alert(1)',
+    'java\tscript:alert(1)',
+    'java\nscript:alert(1)',
+    'vbscript:msgbox(1)',
+    'data:text/html,<script>alert(1)</script>',
+  ];
+
+  const linkIn = (node: ReactNode): HTMLElement | null => {
+    const { container } = render(<>{node}</>);
+    return container.querySelector('a');
+  };
+
+  it.each(DANGEROUS)('url renders %j as inert text, not a link', (payload) => {
+    expect(linkIn(renderCell('url', payload))).toBeNull();
+  });
+
+  it.each(DANGEROUS)('email renders %j as inert text, not a link', (payload) => {
+    expect(linkIn(renderCell('email', payload))).toBeNull();
+  });
+
+  it('still shows the value so nothing silently disappears', () => {
+    expect(textOf(renderCell('url', 'javascript:alert(1)'))).toBe('javascript:alert(1)');
+  });
+
+  it.each([
+    'https://example.test/x',
+    'http://example.test/x',
+    '/relative/path',
+    'relative/path',
+    '?query=1',
+    '#fragment',
+  ])('url keeps %j clickable', (payload) => {
+    expect(linkIn(renderCell('url', payload))).not.toBeNull();
+  });
+
+  it('email keeps an ordinary address clickable', () => {
+    const link = linkIn(renderCell('email', 'a@b.test'));
+    expect(link?.getAttribute('href')).toBe('mailto:a%40b.test');
+  });
+
+  it('image rejects a script-bearing source but allows raster data urls', () => {
+    const rendered = (payload: string) => {
+      const { container } = render(<>{renderCell('image', payload)}</>);
+      return container.querySelector('img');
+    };
+
+    expect(rendered('javascript:alert(1)')).toBeNull();
+    // SVG can execute script when rendered, so it is not treated as raster.
+    expect(rendered('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')).toBeNull();
+    expect(rendered('https://example.test/a.png')).not.toBeNull();
+    expect(rendered('data:image/png;base64,iVBORw0KGgo=')).not.toBeNull();
+  });
+});

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -68,6 +68,49 @@ const asNumber = (value: unknown): number => {
 /** Narrow to a key usable against `enumOptions`. */
 const asKey = (value: unknown): string => String(value);
 
+/**
+ * Schemes safe to place in an `href` or `src`.
+ *
+ * `javascript:` is the reason this exists - React 18 warns about such an href
+ * but still renders it, so a stored value could become a click-to-execute
+ * link. `data:` is excluded for anchors (a data URL can carry HTML) and for
+ * images is allowed only for raster types, since `image/svg+xml` can execute
+ * script when rendered.
+ */
+const LINK_SCHEMES = ['http', 'https'] as const;
+const MAIL_SCHEMES = ['http', 'https', 'mailto'] as const;
+
+const SCHEME_PREFIX = /^([a-z][a-z0-9+.-]*):/i;
+const RASTER_DATA_URL = /^data:image\/(png|jpe?g|gif|webp|avif|bmp|x-icon)[;,]/i;
+
+/**
+ * Whether a value is safe to use as a link or image target.
+ *
+ * A value with no scheme is relative and therefore safe. A value with a scheme
+ * must name one on the allowlist. Whitespace and control characters are
+ * stripped before the check because browsers ignore them inside URLs, so
+ * `java\tscript:alert(1)` navigates exactly as `javascript:alert(1)` does.
+ */
+const hasSafeScheme = (value: string, allowed: readonly string[]): boolean => {
+  // Matching control characters is the entire point: browsers strip them from
+  // URLs, so they must be stripped here too or they hide the scheme.
+  // eslint-disable-next-line no-control-regex
+  const normalised = value.replace(/[\u0000-\u0020\u007F-\u009F]/g, '');
+  const match = SCHEME_PREFIX.exec(normalised);
+  if (!match) return true;
+  return allowed.includes(match[1].toLowerCase());
+};
+
+/** Whether an image source is safe: an allowed scheme, or a raster data URL. */
+const isSafeImageSource = (value: string): boolean => {
+  // Matching control characters is the entire point: browsers strip them from
+  // URLs, so they must be stripped here too or they hide the scheme.
+  // eslint-disable-next-line no-control-regex
+  const normalised = value.replace(/[\u0000-\u0020\u007F-\u009F]/g, '');
+  if (RASTER_DATA_URL.test(normalised)) return true;
+  return hasSafeScheme(value, LINK_SCHEMES);
+};
+
 const DATE_TIME_DISPLAY = 'YYYY-MM-DD HH:mm';
 const DATE_DISPLAY = 'YYYY-MM-DD';
 const TIME_VALUE = 'HH:mm:ss';
@@ -165,6 +208,7 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
         const value = cellValue(col, record);
         if (!isPresent(value)) return '-';
         const address = asText(value);
+        if (!hasSafeScheme(address, MAIL_SCHEMES)) return <span>{address}</span>;
         return <a href={`mailto:${encodeURIComponent(address)}`}>{address}</a>;
       },
     }),
@@ -178,6 +222,9 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
         const value = cellValue(col, record);
         if (!isPresent(value)) return '-';
         const href = asText(value);
+        // An unsafe scheme renders as inert text: the value is still visible,
+        // it simply is not clickable.
+        if (!hasSafeScheme(href, LINK_SCHEMES)) return <span>{href}</span>;
         return (
           <a href={href} target="_blank" rel="noopener noreferrer">
             {href}
@@ -302,7 +349,9 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
       render: (_, record) => {
         const value = cellValue(col, record);
         if (!isPresent(value)) return '-';
-        return <Image src={asText(value)} width={48} height={48} style={{ objectFit: 'cover' }} />;
+        const src = asText(value);
+        if (!isSafeImageSource(src)) return <span>{src}</span>;
+        return <Image src={src} width={48} height={48} style={{ objectFit: 'cover' }} />;
       },
     }),
     formControl: (_col, disabled) => (


### PR DESCRIPTION
Closes #32.

## What was wrong

The `url` field rendered its cell value straight into an `href`:

```tsx
<a href={value} target="_blank" rel="noopener noreferrer">{value}</a>
```

React 18 warns about a `javascript:` href but **still renders it**, so a stored value became a click-to-execute link. The same shape applied to `email` via `mailto:` and to `image` via `src`.

## The fix

A value with **no scheme is relative** and stays clickable. A value **carrying a scheme** must name one on the allowlist — `http`/`https` for links, plus `mailto` for the email column.

Whitespace and control characters are stripped before the check, because browsers ignore them inside URLs. `java\tscript:alert(1)` navigates exactly as `javascript:alert(1)` does, so a naive prefix test would miss it. That case is in the test matrix.

Rejected values **render as inert text rather than disappearing** — the data stays visible, it simply is not a link. Silently blanking a cell would trade one bug for another.

Images additionally accept raster data URLs (`data:image/png`, `jpeg`, `webp`, …) since those are common and inert, but **not `image/svg+xml`**, which can execute script when rendered.

## Tests

23 new cases: seven dangerous payloads across `url` and `email` (including case variants, leading whitespace, and tab/newline-broken schemes), six benign forms that must stay clickable (absolute, relative, query-only, fragment-only), and the image raster/SVG distinction.

## Note

`no-control-regex` fires on the sanitising regex, which is targeted-disabled with a comment — matching control characters is the entire point of that line, and stripping them is what browsers do.

## Verification

```
pnpm lint       0 problems
pnpm test       227 passed  (was 204)
coverage        88.34% statements
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>