### PR TITLE
[fix]: export the whole result set, not just the visible page

### DIFF
--- a/lib/CrudTable.test.tsx
+++ b/lib/CrudTable.test.tsx
@@ -135,7 +135,7 @@ describe('CrudTable toolbar flags', () => {
     await user.hover(screen.getByRole('button', { name: 'ellipsis' }));
 
     expect(await screen.findByText('Refresh')).toBeDefined();
-    expect(screen.queryByText('Export CSV')).toBeNull();
+    expect(screen.queryByText(/^Export/)).toBeNull();
   });
 
   it('offers export entries when export is enabled', async () => {
@@ -145,8 +145,8 @@ describe('CrudTable toolbar flags', () => {
 
     await user.hover(screen.getByRole('button', { name: 'ellipsis' }));
 
-    expect(await screen.findByText('Export CSV')).toBeDefined();
-    expect(screen.getByText('Export JSON')).toBeDefined();
+    expect(await screen.findByText('Export all as CSV')).toBeDefined();
+    expect(screen.getByText('Export all as JSON')).toBeDefined();
   });
 });
 
@@ -459,5 +459,105 @@ describe('CrudTable single delete', () => {
     await user.click(await confirmButton(/Yes, Delete/));
 
     await waitFor(() => expect(remove).toHaveBeenCalledWith(1));
+  });
+});
+
+// #28: export read from the visible page, so "Export CSV" on page 3 of 500
+// wrote ten rows under a label implying everything.
+describe('CrudTable export scope', () => {
+  const many: User[] = Array.from({ length: 25 }, (_, i) => ({
+    id: i + 1,
+    name: `User ${i + 1}`,
+    age: 20 + i,
+    status: i % 2 === 0 ? 'active' : 'inactive',
+  }));
+
+  const openExportMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.hover(screen.getByRole('button', { name: 'ellipsis' }));
+  };
+
+  it('exports every matching row, not just the visible page', async () => {
+    const user = userEvent.setup();
+    const source = new StaticDataSource<User, 'id'>(many, 'id');
+    const listAll = vi.spyOn(source, 'listAll');
+
+    renderTable({ hookConfig: { dataSource: source }, defaultPageSize: 5 });
+    await screen.findByText('User 1');
+
+    await openExportMenu(user);
+    await user.click(await screen.findByText('Export all as JSON'));
+
+    await waitFor(() => expect(listAll).toHaveBeenCalled());
+  });
+
+  it('labels the menu with the scope it will actually export', async () => {
+    const user = userEvent.setup();
+    renderTable({
+      hookConfig: { dataSource: new StaticDataSource<User, 'id'>(many, 'id') },
+      defaultPageSize: 5,
+    });
+    await screen.findByText('User 1');
+
+    await openExportMenu(user);
+
+    expect(await screen.findByText('Export all as CSV')).toBeDefined();
+    expect(screen.queryByText('Export page as CSV')).toBeNull();
+  });
+
+  it('degrades to the visible page when the source cannot list without pagination', async () => {
+    const user = userEvent.setup();
+    // No listAll: an unbounded remote collection cannot safely honour it.
+    const limited: CrudDataSource<User, 'id'> = {
+      list: async (query) => ({ items: many.slice(0, query.pageSize), total: many.length }),
+      create: async () => many[0],
+      update: async () => many[0],
+      remove: async () => undefined,
+    };
+
+    renderTable({ hookConfig: { dataSource: limited }, defaultPageSize: 5 });
+    await screen.findByText('User 1');
+
+    await openExportMenu(user);
+
+    expect(await screen.findByText('Export page as CSV')).toBeDefined();
+  });
+
+  it('honours an explicit page-only scope even when listAll exists', async () => {
+    const user = userEvent.setup();
+    const source = new StaticDataSource<User, 'id'>(many, 'id');
+    const listAll = vi.spyOn(source, 'listAll');
+
+    renderTable({ hookConfig: { dataSource: source }, exportScope: 'page', defaultPageSize: 5 });
+    await screen.findByText('User 1');
+
+    await openExportMenu(user);
+    await user.click(await screen.findByText('Export page as JSON'));
+
+    await waitFor(() => expect(message.warning).not.toHaveBeenCalled());
+    expect(listAll).not.toHaveBeenCalled();
+  });
+
+  it('reports an export failure instead of writing an empty file', async () => {
+    const user = userEvent.setup();
+    const onError = vi.fn();
+    const failing: CrudDataSource<User, 'id'> = {
+      list: async (query) => ({ items: many.slice(0, query.pageSize), total: many.length }),
+      listAll: async () => {
+        throw new Error('too many rows');
+      },
+      create: async () => many[0],
+      update: async () => many[0],
+      remove: async () => undefined,
+    };
+
+    renderTable({ hookConfig: { dataSource: failing, onError }, defaultPageSize: 5 });
+    await screen.findByText('User 1');
+
+    await openExportMenu(user);
+    await user.click(await screen.findByText('Export all as CSV'));
+
+    await waitFor(() =>
+      expect(message.error).toHaveBeenCalledWith('Export failed: too many rows'),
+    );
   });
 });

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -65,6 +65,12 @@ export interface CrudTableConfig<T extends object, K extends keyof T> {
   /** Show ProTable's column visibility and density controls. Defaults to true. */
   enableColumnSettings?: boolean;
   enableExport?: boolean;
+  /**
+   * Whether export covers the whole filtered result set or just the rows on
+   * screen. Defaults to `'all'`, falling back to `'page'` when the data source
+   * cannot list without pagination.
+   */
+  exportScope?: 'all' | 'page';
   customActions?: (record: T, actions: CrudTableActions<T, K>) => React.ReactNode[];
 }
 
@@ -129,6 +135,7 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
     enableBulkOperations = false,
     enableColumnSettings = true,
     enableExport = true,
+    exportScope = 'all',
     customActions,
   } = config;
 
@@ -146,8 +153,10 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
   const [selectedKeys, setSelectedKeys] = useState<React.Key[]>([]);
   const [form] = Form.useForm();
 
-  /** The rows currently displayed, captured for export. */
+  /** The rows currently displayed, and the query that produced them. */
   const visibleRows = useRef<readonly T[]>([]);
+  const lastQuery = useRef<CrudQuery<T>>({ page: 1, pageSize: defaultPageSize });
+  const [exporting, setExporting] = useState(false);
 
   const knownFields = useMemo(
     () => new Set<PropertyKey>(columns.map((col) => col.dataIndex)),
@@ -253,7 +262,9 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
     filter: Record<string, (string | number | boolean)[] | null>,
   ) => {
     try {
-      const page = await crud.dataSource.list(toCrudQuery<T>(params, sort, filter, knownFields));
+      const query = toCrudQuery<T>(params, sort, filter, knownFields);
+      lastQuery.current = query;
+      const page = await crud.dataSource.list(query);
       visibleRows.current = page.items;
       return { data: [...page.items], success: true, total: page.total };
     } catch (thrown) {
@@ -341,30 +352,59 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
     });
   };
 
-  const handleExport = (format: ExportFormat) => {
-    const rows = visibleRows.current;
-    if (rows.length === 0) {
-      message.warning('Nothing to export');
-      return;
+  /**
+   * Whether the whole result set can be exported.
+   *
+   * `listAll` is optional on the interface: a source over an unbounded remote
+   * collection has no safe way to honour it, so the menu degrades to the
+   * visible page and says so rather than silently exporting ten of a thousand
+   * rows under a label implying everything.
+   */
+  const canExportAll = exportScope === 'all' && typeof crud.dataSource.listAll === 'function';
+
+  const handleExport = async (format: ExportFormat) => {
+    setExporting(true);
+    try {
+      const rows = canExportAll
+        ? await crud.dataSource.listAll!({
+            sort: lastQuery.current.sort,
+            filters: lastQuery.current.filters,
+          })
+        : visibleRows.current;
+
+      if (rows.length === 0) {
+        message.warning('Nothing to export');
+        return;
+      }
+
+      const exportColumns = columns
+        // Passwords are masked in the table, so they must not leave in plaintext.
+        .filter((col) => col.fieldType !== 'password')
+        .map((col) => ({
+          title: col.title,
+          dataIndex: String(col.dataIndex),
+          fieldType: col.fieldType,
+          enumOptions: col.enumOptions,
+        }));
+
+      exportData({
+        data: [...rows],
+        columns: exportColumns,
+        filename: title ? title.toLowerCase().replace(/\s+/g, '-') : 'export',
+        format,
+      });
+    } catch (thrown) {
+      const error = toError(thrown);
+      hookConfig.onError?.('list', error);
+      message.error(`Export failed: ${error.message}`);
+    } finally {
+      setExporting(false);
     }
-
-    const exportColumns = columns
-      // Passwords are masked in the table, so they must not leave in plaintext.
-      .filter((col) => col.fieldType !== 'password')
-      .map((col) => ({
-        title: col.title,
-        dataIndex: String(col.dataIndex),
-        fieldType: col.fieldType,
-        enumOptions: col.enumOptions,
-      }));
-
-    exportData({
-      data: [...rows],
-      columns: exportColumns,
-      filename: title ? title.toLowerCase().replace(/\s+/g, '-') : 'export',
-      format,
-    });
   };
+
+  // The label states the scope outright: "Export CSV" on page 3 of 500 writing
+  // ten rows was correct-looking and wrong.
+  const exportLabel = canExportAll ? 'Export all' : 'Export page';
 
   return (
     <ProConfigProvider needDeps intl={enUSIntl}>
@@ -397,9 +437,24 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
               items: [
                 ...(enableExport
                   ? [
-                      { key: 'export-csv', label: 'Export CSV', onClick: () => handleExport('csv') },
-                      { key: 'export-json', label: 'Export JSON', onClick: () => handleExport('json') },
-                      { key: 'export-excel', label: 'Export Excel', onClick: () => handleExport('xlsx') },
+                      {
+                        key: 'export-csv',
+                        label: `${exportLabel} as CSV`,
+                        disabled: exporting,
+                        onClick: () => void handleExport('csv'),
+                      },
+                      {
+                        key: 'export-json',
+                        label: `${exportLabel} as JSON`,
+                        disabled: exporting,
+                        onClick: () => void handleExport('json'),
+                      },
+                      {
+                        key: 'export-excel',
+                        label: `${exportLabel} as Excel`,
+                        disabled: exporting,
+                        onClick: () => void handleExport('xlsx'),
+                      },
                       { type: 'divider' as const },
                     ]
                   : []),


### PR DESCRIPTION
Closes #28.

## What was wrong

`handleExport` read from `visibleRows`, populated with the most recent page response. So **"Export CSV" on page 3 of a 500-row table wrote ten rows** — under a menu label implying the whole dataset. Silent, plausible-looking, wrong output.

`exportAllData` already existed in `utils/exportData.ts` and was exported from the barrel. It was never wired to the UI.

## The fix

Export now goes through the data source's `listAll`, **reusing the filters and sort from the last request** so it exports what the user is actually looking at, minus the pagination.

`listAll` is optional on `CrudDataSource` — a source over an unbounded remote collection has no safe way to honour it — so the menu degrades to the visible page rather than failing.

## The labels changed, deliberately

```
Export CSV          →   Export all as CSV
                        Export page as CSV   (when all is unavailable)
```

The old wording is exactly what made the bug invisible. The menu now states which it will do.

`exportScope: 'page'` opts out explicitly where fetching everything would be expensive.

## Also

- A failed export reports through `onError` and a toast instead of writing an empty file
- Menu entries disable while an export is in flight

## Tests

Five new cases: full-set export calls `listAll`; labels match the effective scope; a source without `listAll` degrades to page scope and says so; `exportScope: 'page'` is honoured even when `listAll` exists; a failing `listAll` surfaces an error rather than an empty file.

## Verification

```
pnpm lint    0 problems
pnpm test    232 passed  (was 227)
coverage     passes at the raised thresholds
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>