### PR TITLE
[api]: rename the xlsx export format to excel

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -97,6 +97,25 @@ New in 0.6.0: `paramNames` renames pagination and sort parameters, and
 `methods` selects the HTTP verb per operation — so an API that does not speak
 `current` / `pageSize` / `PUT` no longer needs a hand-written `operations` bag.
 
+### 5b. Export format renamed
+
+`'xlsx'` is now `'excel'`, and `exportToXLSX` is now `exportToExcel`.
+
+```diff
+- exportData({ data, columns, format: 'xlsx' });
++ exportData({ data, columns, format: 'excel' });
+```
+
+The output is unchanged — Excel 2003 SpreadsheetML written to a `.xls` file.
+Only the name changed, because `xlsx` promised OOXML, which this library does
+not produce and will not without taking on a ZIP implementation.
+
+**Known limitation:** because the content is SpreadsheetML and the extension is
+`.xls`, Excel 2016 and later show *"The file format and extension of
+'export.xls' don't match. The file could be corrupted or unsafe."* on open. The
+file is intact and opens correctly once confirmed. Use CSV if you need an
+export that opens without a prompt.
+
 ### 6. Hook return shape
 
 | 0.5.x | 0.6.0 |

--- a/README.md
+++ b/README.md
@@ -799,7 +799,10 @@ import { CrudTableLazy } from 'antd-crud-table';
 ### Coming Soon
 - 🌐 **WebSocket Integration**: Real-time updates
 - 📊 **Virtual Scrolling**: Handle thousands of rows
-- 📤 **Export Functionality**: CSV/Excel export
+- 📤 **Export Functionality**: CSV, JSON and Excel export, covering the whole
+  filtered result set rather than the visible page.
+  Excel output is Excel 2003 SpreadsheetML in a `.xls` file, not OOXML — Excel
+  2016+ shows a format/extension mismatch prompt on open. Use CSV to avoid it.
 - 🎨 **Theme Support**: Multiple UI themes
 - 🔍 **Advanced Filters**: Complex filtering UI
 - 📱 **Mobile Optimization**: Better mobile experience

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -453,7 +453,7 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
                         key: 'export-excel',
                         label: `${exportLabel} as Excel`,
                         disabled: exporting,
-                        onClick: () => void handleExport('xlsx'),
+                        onClick: () => void handleExport('excel'),
                       },
                       { type: 'divider' as const },
                     ]

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,7 +61,7 @@ export {
   exportData,
   exportToCSV,
   exportToJSON,
-  exportToXLSX,
+  exportToExcel,
   exportAllData,
 } from './utils/exportData';
 export type { ExportFormat } from './utils/exportData';

--- a/lib/utils/exportData.test.ts
+++ b/lib/utils/exportData.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { exportToCSV, exportToJSON, exportToXLSX } from './exportData';
+import { exportData, exportToCSV, exportToJSON, exportToExcel } from './exportData';
 
 interface Row {
   id: number;
@@ -83,9 +83,9 @@ describe('exportToJSON', () => {
   });
 });
 
-describe('exportToXLSX', () => {
+describe('exportToExcel', () => {
   it('emits SpreadsheetML that Excel recognizes', async () => {
-    exportToXLSX({ data: rows, columns, filename: 'people' });
+    exportToExcel({ data: rows, columns, filename: 'people' });
 
     const xml = await lastContent();
     expect(xml).toContain('<?mso-application progid="Excel.Sheet"?>');
@@ -98,7 +98,7 @@ describe('exportToXLSX', () => {
   });
 
   it('escapes XML-significant characters', async () => {
-    exportToXLSX({
+    exportToExcel({
       data: [{ id: 1, name: '<b>&"x"</b>', active: true, status: 'active' }],
       columns,
       filename: 'people',
@@ -159,7 +159,7 @@ describe('CSV formula injection', () => {
   });
 
   it('leaves SpreadsheetML content literal - ss:Formula is never emitted', async () => {
-    exportToXLSX({
+    exportToExcel({
       data: [{ v: '=1+1' }],
       columns: [{ title: 'V', dataIndex: 'v' }],
     });
@@ -167,5 +167,20 @@ describe('CSV formula injection', () => {
     expect(xml).toContain('<Cell><Data ss:Type="String">=1+1</Data></Cell>');
     expect(xml).not.toContain('ss:Formula');
     expect(xml).not.toContain("'=1+1");
+  });
+});
+
+describe('export format naming', () => {
+  it('routes the excel format to the SpreadsheetML writer', async () => {
+    exportData({ data: rows, columns, filename: 'people', format: 'excel' });
+
+    const xml = await lastContent();
+    expect(xml).toContain('<?mso-application progid="Excel.Sheet"?>');
+    expect(capturedNames.at(-1)).toBe('people.xls');
+  });
+
+  it('defaults to CSV when no format is given', async () => {
+    exportData({ data: rows, columns, filename: 'people' });
+    expect(capturedNames.at(-1)).toBe('people.csv');
   });
 });

--- a/lib/utils/exportData.ts
+++ b/lib/utils/exportData.ts
@@ -1,4 +1,12 @@
-export type ExportFormat = 'csv' | 'json' | 'xlsx';
+/**
+ * Supported export formats.
+ *
+ * `excel` emits Excel 2003 SpreadsheetML, not OOXML. It was previously named
+ * `xlsx`, which promised a format this library does not produce - writing a
+ * real .xlsx means owning a ZIP implementation, which is not worth a
+ * dependency-free library taking on. See exportToExcel for the tradeoff.
+ */
+export type ExportFormat = 'csv' | 'json' | 'excel';
 
 interface ColumnOption {
   title?: string;
@@ -139,11 +147,17 @@ export const exportToJSON = <T>(options: ExportOptions<T>): void => {
 /**
  * Export data as an Excel-compatible spreadsheet.
  *
- * Emits Excel 2003 SpreadsheetML (an XML dialect Excel and LibreOffice
- * open natively from a .xls file) rather than a real OOXML .xlsx, which
- * would require a dedicated dependency such as exceljs.
+ * Emits Excel 2003 SpreadsheetML - an XML dialect Excel and LibreOffice open
+ * natively - written to a `.xls` file, rather than a real OOXML `.xlsx`, which
+ * would mean adding a dependency such as exceljs or hand-rolling a ZIP writer.
+ *
+ * Known consequence: because the content is SpreadsheetML and the extension is
+ * `.xls`, Excel 2016 and later show "The file format and extension don't
+ * match" on open. The file is intact and opens correctly once confirmed. The
+ * format is named `excel` rather than `xlsx` so the API does not claim
+ * otherwise.
  */
-export const exportToXLSX = <T extends object>(options: ExportOptions<T>): void => {
+export const exportToExcel = <T extends object>(options: ExportOptions<T>): void => {
   const { data, columns, filename = 'export' } = options;
 
   // Get visible columns
@@ -225,8 +239,8 @@ export const exportData = <T extends object>(
     case 'json':
       exportToJSON(options);
       break;
-    case 'xlsx':
-      exportToXLSX(options);
+    case 'excel':
+      exportToExcel(options);
       break;
     default:
       exportToCSV(options);


### PR DESCRIPTION
Closes #34.

## The problem

`ExportFormat` offered `'xlsx'` and the toolbar said "Excel", but `exportToXLSX` emits **Excel 2003 SpreadsheetML**, not OOXML. The name promised a format the library does not produce.

## What changed

Names only — the output bytes are identical.

```diff
- export type ExportFormat = 'csv' | 'json' | 'xlsx';
+ export type ExportFormat = 'csv' | 'json' | 'excel';

- exportToXLSX(...)
+ exportToExcel(...)
```

## What deliberately did not change

Still SpreadsheetML in a `.xls` file. Emitting a real `.xlsx` means owning a ZIP implementation (or adding `exceljs`), and neither is a reasonable thing for a dependency-free library to take on for one export format. The file does open in Excel and LibreOffice.

**The known limitation is now stated rather than left to be discovered.** Because the content is SpreadsheetML and the extension is `.xls`, Excel 2016+ prompts:

> The file format and extension of 'export.xls' don't match. The file could be corrupted or unsafe.

The file is intact and opens once confirmed. This is documented in four places — the `ExportFormat` type, the `exportToExcel` docblock, the README feature list, and the migration guide — each pointing at CSV where a prompt-free export matters.

Renaming without fixing the warning is the honest trade here: it removes the false promise in the API surface without pretending the underlying limitation is gone.

## Verification

```
pnpm lint          0 problems
pnpm test          234 passed
coverage           90.74% statements
pnpm build:static  ok
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>