### PR TITLE
[packaging]: declare sideEffects and engines, stop shipping test types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Everything below lands as **0.6.0**. It is a breaking release; see
+[MIGRATION.md](./MIGRATION.md), where every break is a compile error rather than
+a silent behaviour change.
+
+### Security
+
+- CSV and Excel exports no longer carry formula injection. Quoting a cell does
+  not stop a spreadsheet evaluating it, so a stored value beginning `=`, `+`,
+  `-`, `@`, tab or CR is now prefixed to mark it as text. Genuinely numeric
+  values are left alone.
+- `url`, `email` and `image` columns render only allowlisted schemes. React 18
+  warns about a `javascript:` href but still renders it, so a stored value could
+  become a click-to-execute link. Rejected values render as inert text.
+
+### Added
+
+- `CrudDataSource<T, K>` interface with `StaticDataSource`,
+  `LocalStorageDataSource`, `RestDataSource` and `CustomDataSource`
+  implementations, all usable and testable without React.
+- `dataSource` strategy, for supplying a source you construct and own.
+- `storageKey` strategy on `useCrudTable`, without the wrapper hook.
+- `generateId` for overriding identity assignment.
+- `notifications: false` to suppress the built-in toasts.
+- `exportScope` for choosing between the whole result set and the visible page.
+- `paramNames` and `methods` on the REST source, plus protected `buildListUrl`,
+  `buildRecordPath` and `serializeSort` seams for subclassing.
+- `RestError` carrying the HTTP status and response body.
+- React 19 support alongside 18, verified against both.
+
+### Changed
+
+- **Breaking.** `DataType` (`Record<string, any>`) is gone; record types are
+  constrained to `object`, so plain interfaces work without an index signature.
+- **Breaking.** Components take a row-key type parameter: `CrudTable<User, 'id'>`.
+- **Breaking.** `CrudColumn<T>` is distributed over `keyof T`, binding
+  `dataIndex` to a real property. `title` must be a string.
+- **Breaking.** Operations renamed to match the data-source interface:
+  `getList` → `list`, `delete` → `remove`, `{ data, total }` → `{ items, total }`.
+- **Breaking.** Hook surface: `delete` → `remove`, `operations` → `dataSource`,
+  `state.current` → `state.page`, `setCurrentPage` → `setPage`, and
+  `state.error` is an `Error` rather than a string.
+- **Breaking.** REST config: `endpoints.delete` → `endpoints.remove`,
+  `transform.response` → `parseResponse`, `transform.request` → `serializeRequest`.
+- **Breaking.** Export format `'xlsx'` → `'excel'`, `exportToXLSX` → `exportToExcel`.
+  The output is unchanged: Excel 2003 SpreadsheetML in a `.xls` file. Only the
+  name changed, because `xlsx` promised OOXML this library does not produce.
+- **Breaking.** Redundant default exports removed from `useCrudTable`,
+  `useLocalStorageCrud` and `exportData`; use the named exports. The barrel's
+  default export of `CrudTable` is unchanged.
+- `onError` receives a real `Error`, and now fires for list failures — the
+  initial load, pagination, sorting and search.
+- Export covers the whole filtered result set rather than the visible page, and
+  the menu states which it will do.
+- Sorting collates by locale, so ordering is alphabetical rather than
+  capitals-first.
+- `@typescript-eslint/no-explicit-any` is an error rather than a warning.
+
+### Fixed
+
+- Mutations issued two list requests each: the hook refreshed while the table
+  also reloaded, and the hook's copy was then discarded.
+- `onError` never fired for the primary list load, and the underlying error was
+  replaced with a fixed string.
+- An inline `staticData` literal discarded every created and edited row whenever
+  the parent re-rendered.
+- Non-numeric row keys all generated id `1`, producing duplicate keys and
+  sending `update`/`remove` to the wrong record.
+- Search values silently overwrote column filters for the same key.
+- Bulk delete reported success when individual deletes failed, and cleared the
+  selection regardless.
+- `enableColumnSettings` was declared but never read.
+- The create/edit modal rendered Chinese OK and Cancel buttons.
+- Hook callbacks were recreated on every render, defeating their memoization.
+- Test type declarations were being published in the package.
+
+### Packaging
+
+- `sideEffects: ["*.css"]` and an `engines.node` floor declared.
+- Rollup's export mode stated explicitly, removing the mixed-export warnings.
+- README documents the required stylesheet import, which it never did.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -167,6 +167,28 @@ capitals-first.
 `peerDependencies` now accept `^18.0.0 || ^19.0.0`. Nothing to change if you are
 on 18; React 19 users no longer need `--force` or an override.
 
+### 8c. Default exports removed from utility modules
+
+`useCrudTable`, `useLocalStorageCrud` and `exportData` no longer have default
+exports — the named exports already existed, and the mix meant CJS consumers
+reached them through `.default`.
+
+```diff
+- import useCrudTable from 'antd-crud-table/hooks/useCrudTable';
++ import { useCrudTable } from 'antd-crud-table/hooks/useCrudTable';
+```
+
+`import CrudTable from 'antd-crud-table'` is unchanged.
+
+### 8d. Stylesheet import
+
+Not a change, but frequently missed and previously undocumented: the build
+extracts CSS to a separate file, so it has to be imported once.
+
+```ts
+import 'antd-crud-table/styles.css';
+```
+
 ### 9. New capabilities
 
 - `dataSource` strategy — construct and own a source directly

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 **Supported peers:** React 18 or 19, antd 6, `@ant-design/pro-components` 2.8+.
 Both React majors are verified by the test suite.
 
+### Stylesheet
+
+The library build extracts its CSS to a separate file, so **you must import it
+once** — importing the component alone leaves the table unstyled:
+
+```ts
+import 'antd-crud-table/styles.css';
+```
+
 > **Upgrading from 0.5.x?** 0.6.0 makes the API strictly typed and replaces the
 > data strategies with classes behind a single `CrudDataSource` interface.
 > See [MIGRATION.md](./MIGRATION.md) — every break is a compile error, not a

--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -324,4 +324,3 @@ export const useCrudTable = <T extends object, K extends keyof T>(
   );
 };
 
-export default useCrudTable;

--- a/lib/hooks/useLocalStorageCrud.ts
+++ b/lib/hooks/useLocalStorageCrud.ts
@@ -38,4 +38,3 @@ export const useLocalStorageCrud = <T extends object, K extends keyof T>(
   return actions;
 };
 
-export default useLocalStorageCrud;

--- a/lib/utils/exportData.ts
+++ b/lib/utils/exportData.ts
@@ -265,4 +265,3 @@ export const exportAllData = async <T extends object>(
   }
 };
 
-export default exportData;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "components"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "author": "Maifee Ul Asad<maifeeulasad@gmail.com>",
   "packageManager": "pnpm@10.25.0",
   "scripts": {
@@ -102,5 +105,8 @@
   },
   "files": [
     "dist"
+  ],
+  "sideEffects": [
+    "*.css"
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -23,5 +23,9 @@
     },
     "include": [
         "lib"
+    ],
+    "exclude": [
+        "lib/**/*.test.ts",
+        "lib/**/*.test.tsx"
     ]
 }

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -42,6 +42,11 @@ export default defineConfig({
     rollupOptions: {
       external: isExternal,
       output: {
+        // The barrel intentionally re-exports CrudTable as default so
+        // `import CrudTable from 'antd-crud-table'` keeps working alongside
+        // the named exports. Stating this stops rollup guessing the export
+        // mode and warning about the mix.
+        exports: 'named',
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',


### PR DESCRIPTION
Closes #38.

Adds the missing distribution metadata — and fixes two genuine packaging defects found while verifying it.

## Test declarations were being published

`tsconfig.build.json` included all of `lib` with no `exclude`, so **11 `*.test.d.ts` files shipped in `dist`**:

```
dist/CrudTable.test.d.ts
dist/core/RestDataSource.test.d.ts
dist/fields/registry.test.d.ts
dist/hooks/useCrudTable.test.d.ts
...
```

The component and registry suites added in #47 made it worse. Excluded now — `find dist -name "*test*"` goes from 11 to 0.

## The stylesheet import was undocumented

`grep "styles.css" README.md` returned nothing. The library build **extracts CSS to a separate file and strips the import from the emitted JS**, so a consumer following the README got an unstyled table with no indication why. The `exports` map already exposed `./styles.css`; nothing told anyone to use it.

Now documented in the README and the migration guide.

## `sideEffects` is belt-and-braces here, not load-bearing

I probed this with a real consumer build rather than assuming. Because the CSS is extracted at library-build time, **there is no CSS import left in `dist` for a bundler to tree-shake away** — so `sideEffects` cannot be what protects the styles, and the README fix above is the actual answer.

It is still accurate metadata (only CSS files carry side effects) and guards the case where the build stops extracting, so it is declared — but I'd rather say plainly what it does and does not do than imply it fixed a problem it doesn't.

## Mixed exports

Redundant default exports removed from `useCrudTable`, `useLocalStorageCrud` and `exportData` — the named exports already existed, and the mix meant CJS consumers reached them through `.default`. The barrel keeps its deliberate default export of `CrudTable`, with rollup's export mode now stated explicitly rather than guessed.

Four `MIXED_EXPORTS` warnings → zero.

## Also

- `engines.node: ">=20.19.0"`
- `CHANGELOG.md` covering the whole 0.6.0 surface, Keep-a-Changelog format, no release-automation dependency

## Verification

```
pnpm lint         0 problems
pnpm test         234 passed
pnpm build:lib    0 warnings, 0 test artifacts in dist
dist CSS          emitted
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>