### PR TITLE
[version]: set version to `0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-08-30
 
-Everything below lands as **0.6.0**. It is a breaking release; see
-[MIGRATION.md](./MIGRATION.md), where every break is a compile error rather than
-a silent behaviour change.
+A breaking release. See [MIGRATION.md](./MIGRATION.md) — every break is a
+compile error rather than a silent behaviour change.
 
 ### Security
 
@@ -82,8 +81,36 @@ a silent behaviour change.
 - Hook callbacks were recreated on every render, defeating their memoization.
 - Test type declarations were being published in the package.
 
+- Test type declarations were being published in the package; 11 `*.test.d.ts`
+  files shipped in `dist`.
+- The demo and the library both built to `dist`, which is the published
+  package — a stale demo build could have been packed into a release. The demo
+  now builds to `dist-site`.
+
+### Documentation
+
+- Generated API reference (TypeDoc) covering every public export, with zero
+  undocumented members.
+- Storybook playground: one story per field type, derived from the registry so
+  new types are covered automatically, plus every data strategy and toolbar flag.
+- `pnpm build:site` produces one tree — demo at the root, Storybook under
+  `/storybook`, API reference under `/api`.
+- [REST dialect recipes](./docs/rest-recipes.md) for offset/limit, Django REST
+  Framework, JSON:API and auth. Each recipe is a compiled test, so they cannot
+  drift from the API.
+- `MIGRATION.md` covering the 0.5.x → 0.6.0 upgrade.
+- The required stylesheet import is documented, which it never was.
+
 ### Packaging
 
 - `sideEffects: ["*.css"]` and an `engines.node` floor declared.
 - Rollup's export mode stated explicitly, removing the mixed-export warnings.
-- README documents the required stylesheet import, which it never did.
+
+### Internal
+
+- Test coverage went from 42% to 91% of statements, with thresholds enforced.
+  `CrudTable.tsx` and the field registry were both at 0%.
+- Testing Library's cleanup was never registering, so renders accumulated
+  across tests in the same file.
+
+[0.6.0]: https://github.com/maifeeulasad/antd-crud-table/releases/tag/v0.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "antd-crud-table",
   "private": false,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "homepage": "https://github.com/maifeeulasad/antd-crud-table",
   "repository": {


### PR DESCRIPTION
Closes the 0.6.0 changelog and bumps the manifest. All 22 tracked issues are resolved.

## What 0.6.0 contains

**Security** — CSV/Excel formula injection; `javascript:` URLs in link and image columns.

**Correctness** — double list request per mutation; `onError` silent on the list path; inline `staticData` discarding rows; duplicate IDs for non-numeric row keys; search values clobbering column filters; bulk delete reporting success on failure; `enableColumnSettings` never implemented; export writing only the visible page; Chinese modal buttons.

**Architecture** — `CrudDataSource<T, K>` with four class implementations; `any` eliminated from the public API, with `no-explicit-any` now an error.

**Tooling** — coverage gate, TypeDoc, Storybook, combined site build, React 19 support.

## Numbers

```
                 before      after
Tests               25    →    239
Coverage         42.5%    →   90.7% statements
Lint warnings       49    →      0   (and `any` is now an error)
Public `any`      many    →      0
```

## Before releasing

⚠️ **The three workflows are still postfixed `.disable`.** Nothing publishes on a GitHub release until that postfix is dropped — deliberate while the work was verified locally, but it means:

- `tonpm.yml.disable` will not publish to npm
- `toghpage.yml.disable` will not deploy the site
- `ci.yml.disable` will not run on PRs

Re-enable by renaming the three files back. The CI workflow now also matrixes React 18/19 and typechecks the demo app, and the Pages workflow publishes `dist-site`.

## Verification

```
pnpm lint          0 problems
pnpm test          239 passed
pnpm test:coverage 90.74% stmts / 82.67% branch / 91.77% func / 91.94% lines
tsc build + app    clean
pnpm build:lib     ok
pnpm build:site    ok
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>