### PR TITLE
[feat]: localize every user-visible string

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -189,6 +189,20 @@ extracts CSS to a separate file, so it has to be imported once.
 import 'antd-crud-table/styles.css';
 ```
 
+### 8e. Localization
+
+Not a break, but a behaviour change worth knowing: the table now follows the
+surrounding antd `ConfigProvider` instead of pinning ProTable to English. If
+your app sets a non-English locale, the table's chrome will now follow it.
+
+With no provider present the table supplies English, which is what previously
+leaked antd's Chinese defaults into the pagination and modal footer.
+
+`FieldTypeDefinition` hooks take an extra `locale` argument — `column(col,
+locale)`, `formControl(col, disabled, locale)` and `rules(col, locale)`. This
+only affects code that registers custom field types or calls the registry
+directly.
+
 ### 9. New capabilities
 
 - `dataSource` strategy — construct and own a source directly

--- a/README.md
+++ b/README.md
@@ -12,6 +12,49 @@ Connecting to an API that does not speak the default dialect?
 See [REST dialect recipes](./docs/rest-recipes.md) — offset/limit, Django REST
 Framework, JSON:API, and auth.
 
+### Localization
+
+The table follows the antd `ConfigProvider` around it, so setting your app
+locale once localizes the pagination, date pickers, empty states and the
+ProTable chrome:
+
+```tsx
+import { ConfigProvider } from 'antd';
+import frFR from 'antd/locale/fr_FR';
+
+<ConfigProvider locale={frFR}>
+  <CrudTable {...config} />
+</ConfigProvider>
+```
+
+**With no `ConfigProvider` in the tree the table supplies English itself.**
+antd components otherwise fall back to their own built-in defaults, which is
+why a table used outside a provider previously showed Chinese pagination and
+modal buttons beside English ProTable chrome.
+
+The library's own wording — `Actions`, `Edit`, `New`, the confirmations, the
+export menu, the toasts — comes from a `locale` prop. Supply only what you want
+to change; anything omitted stays English:
+
+```tsx
+<CrudTable
+  locale={{
+    actions: 'Aktionen',
+    edit: 'Bearbeiten',
+    delete: 'Löschen',
+    create: 'Neu',
+    confirmDeleteTitle: 'Wirklich löschen?',
+    deleteSelected: (count) => `${count} entfernen`,
+  }}
+  {...config}
+/>
+```
+
+Interpolated strings are functions rather than templates with placeholders, so
+a translation cannot silently drop a value or reorder its arguments — the
+compiler checks it. The full contract is `CrudTableLocale`, and `enUS` is the
+exported default.
+
 ### Stylesheet
 
 The library build extracts its CSS to a separate file, so **you must import it

--- a/lib/CrudTable.tsx
+++ b/lib/CrudTable.tsx
@@ -1,7 +1,7 @@
 import { PlusOutlined, EllipsisOutlined } from '@ant-design/icons';
 import type { ProColumns } from '@ant-design/pro-components';
-import { ProTable, ProConfigProvider, enUSIntl } from '@ant-design/pro-components';
-import { Button, Dropdown, message, Modal, Form } from 'antd';
+import { ProTable, ProConfigProvider } from '@ant-design/pro-components';
+import { Button, ConfigProvider, Dropdown, message, Modal, Form } from 'antd';
 import type { FormRule } from 'antd';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { SortOrder } from 'antd/es/table/interface';
@@ -12,6 +12,8 @@ import type { CrudTableActions, UseCrudTableOptions } from './hooks/useCrudTable
 import { getFieldDefinition } from './fields/registry';
 import type { FieldType } from './fields/registry';
 import type { EnumOption, FieldColumn } from './fields/types';
+import { useResolvedLocale } from './locale/useResolvedLocale';
+import type { PartialCrudTableLocale } from './locale/types';
 import type { CrudFilters, CrudQuery, CrudSort } from './core';
 import { exportData } from './utils/exportData';
 import type { ExportFormat } from './utils/exportData';
@@ -89,6 +91,15 @@ export interface CrudTableConfig<T extends object, K extends keyof T> {
   exportScope?: 'all' | 'page';
   /** Extra per-row controls, appended after Edit and Delete. */
   customActions?: (record: T, actions: CrudTableActions<T, K>) => React.ReactNode[];
+
+  /**
+   * Overrides for the library's own wording.
+   *
+   * antd and ProTable chrome follow the surrounding `ConfigProvider`; this is
+   * for the strings the library itself produces. Anything omitted falls back
+   * to English.
+   */
+  locale?: PartialCrudTableLocale;
 }
 
 /** ProTable hands search values back as an untyped bag; this is that bag. */
@@ -168,11 +179,15 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
     enableExport = true,
     exportScope = 'all',
     customActions,
+    locale,
   } = config;
+
+  const { strings, intl, antdLocale } = useResolvedLocale(locale);
 
   const crud = useCrudTable<T, K>(rowKey, {
     defaultPageSize,
     ...hookConfig,
+    locale: strings,
     // The table renders from ProTable's own request pipeline and reloads
     // through actionRef. Letting the hook also re-read would issue two list
     // requests for every write.
@@ -237,17 +252,17 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
   const handleDelete = useCallback(
     (id: T[K]) => {
       Modal.confirm({
-        title: 'Are you sure?',
-        content: 'This action cannot be undone.',
-        okText: 'Yes, Delete',
+        title: strings.confirmDeleteTitle,
+        content: strings.confirmDeleteContent,
+        okText: strings.confirmDeleteOk,
         okType: 'danger',
-        cancelText: 'Cancel',
+        cancelText: strings.cancel,
         onOk: async () => {
           if (await crud.remove(id)) crud.actionRef.current?.reload();
         },
       });
     },
-    [crud],
+    [crud, strings],
   );
 
   const enhancedColumns = useMemo<ProColumns<T>[]>(() => {
@@ -260,16 +275,16 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
         title: col.title,
         search: col.searchable !== false,
       };
-      return { ...base, ...(definition.column?.(structural) as Partial<ProColumns<T>>) };
+      return { ...base, ...(definition.column?.(structural, strings) as Partial<ProColumns<T>>) };
     });
 
     mapped.push({
-      title: 'Actions',
+      title: strings.actions,
       valueType: 'option',
       width: 200,
       render: (_, record: T) => [
         <Button key="edit" type="link" size="small" onClick={() => openModal(record)}>
-          Edit
+          {strings.edit}
         </Button>,
         <Button
           key="delete"
@@ -278,14 +293,14 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
           danger
           onClick={() => handleDelete(record[rowKey])}
         >
-          Delete
+          {strings.delete}
         </Button>,
         ...(customActions?.(record, crud) ?? []),
       ],
     });
 
     return mapped;
-  }, [columns, asFieldColumn, openModal, handleDelete, rowKey, customActions, crud]);
+  }, [columns, asFieldColumn, openModal, handleDelete, rowKey, customActions, crud, strings]);
 
   const handleRequest = async (
     params: RequestParams,
@@ -346,16 +361,16 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
 
   const handleBulkDelete = () => {
     if (selectedKeys.length === 0) {
-      message.warning('Please select items to delete');
+      message.warning(strings.selectItemsToDelete);
       return;
     }
 
     Modal.confirm({
-      title: `Delete ${selectedKeys.length} items?`,
-      content: 'This action cannot be undone.',
-      okText: 'Yes, Delete All',
+      title: strings.confirmBulkDeleteTitle(selectedKeys.length),
+      content: strings.confirmDeleteContent,
+      okText: strings.confirmBulkDeleteOk,
       okType: 'danger',
-      cancelText: 'Cancel',
+      cancelText: strings.cancel,
       onOk: async () => {
         const outcomes = await Promise.all(
           selectedKeys.map(async (key) => ({
@@ -371,10 +386,14 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
         setSelectedKeys(failed.map((outcome) => outcome.key));
 
         if (failed.length === 0) {
-          message.success(`Deleted ${outcomes.length} items`);
+          message.success(strings.bulkDeleteSuccess(outcomes.length));
         } else {
           message.error(
-            `Deleted ${outcomes.length - failed.length} of ${outcomes.length}. ${failed.length} failed.`,
+            strings.bulkDeletePartial(
+              outcomes.length - failed.length,
+              outcomes.length,
+              failed.length,
+            ),
           );
         }
 
@@ -404,7 +423,7 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
         : visibleRows.current;
 
       if (rows.length === 0) {
-        message.warning('Nothing to export');
+        message.warning(strings.nothingToExport);
         return;
       }
 
@@ -427,7 +446,7 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
     } catch (thrown) {
       const error = toError(thrown);
       hookConfig.onError?.('list', error);
-      message.error(`Export failed: ${error.message}`);
+      message.error(strings.exportFailed(error.message));
     } finally {
       setExporting(false);
     }
@@ -435,10 +454,10 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
 
   // The label states the scope outright: "Export CSV" on page 3 of 500 writing
   // ten rows was correct-looking and wrong.
-  const exportLabel = canExportAll ? 'Export all' : 'Export page';
+  const exportLabel = canExportAll ? strings.exportAll : strings.exportPage;
 
-  return (
-    <ProConfigProvider needDeps intl={enUSIntl}>
+  const table = (
+    <ProConfigProvider needDeps intl={intl}>
       <ProTable<T>
         headerTitle={title}
         rowKey={rowKey as string}
@@ -453,12 +472,12 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
         }
         toolBarRender={() => [
           <Button key="add" type="primary" icon={<PlusOutlined />} onClick={() => openModal()}>
-            New
+            {strings.create}
           </Button>,
           ...(enableBulkOperations && selectedKeys.length > 0
             ? [
                 <Button key="bulk-delete" danger onClick={handleBulkDelete}>
-                  Delete Selected ({selectedKeys.length})
+                  {strings.deleteSelected(selectedKeys.length)}
                 </Button>,
               ]
             : []),
@@ -470,26 +489,26 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
                   ? [
                       {
                         key: 'export-csv',
-                        label: `${exportLabel} as CSV`,
+                        label: exportLabel('CSV'),
                         disabled: exporting,
                         onClick: () => void handleExport('csv'),
                       },
                       {
                         key: 'export-json',
-                        label: `${exportLabel} as JSON`,
+                        label: exportLabel('JSON'),
                         disabled: exporting,
                         onClick: () => void handleExport('json'),
                       },
                       {
                         key: 'export-excel',
-                        label: `${exportLabel} as Excel`,
+                        label: exportLabel('Excel'),
                         disabled: exporting,
                         onClick: () => void handleExport('excel'),
                       },
                       { type: 'divider' as const },
                     ]
                   : []),
-                { key: 'refresh', label: 'Refresh', onClick: () => crud.actionRef.current?.reload() },
+                { key: 'refresh', label: strings.refresh, onClick: () => crud.actionRef.current?.reload() },
               ],
             }}
           >
@@ -507,7 +526,7 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
       />
 
       <Modal
-        title={editing ? 'Edit Item' : 'Create Item'}
+        title={editing ? strings.editTitle : strings.createTitle}
         open={modalOpen}
         onOk={handleOk}
         onCancel={() => setModalOpen(false)}
@@ -516,8 +535,8 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
         // antd's default locale and renders Chinese buttons. Stated
         // explicitly, matching the Modal.confirm calls and every other
         // hardcoded string in this component.
-        okText="OK"
-        cancelText="Cancel"
+        okText={strings.ok}
+        cancelText={strings.cancel}
         destroyOnHidden
         width={600}
       >
@@ -531,11 +550,12 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
             const userRules =
               col.formConfig?.rules ??
               (col.formConfig?.required
-                ? [{ required: true, message: `${col.title} is required` }]
+                ? [{ required: true, message: strings.requiredField(col.title) }]
                 : []);
-            const rules: FormRule[] = [...(definition.rules?.(structural) ?? []), ...userRules];
+            const rules: FormRule[] = [...(definition.rules?.(structural, strings) ?? []), ...userRules];
 
-            const control = col.formConfig?.component ?? definition.formControl(structural, disabled);
+            const control =
+              col.formConfig?.component ?? definition.formControl(structural, disabled, strings);
             if (!control) return null;
 
             return (
@@ -554,6 +574,14 @@ const CrudTable = <T extends object, K extends keyof T>(config: CrudTableConfig<
       </Modal>
     </ProConfigProvider>
   );
+
+  // antd's own components - pagination, empty states, the modal footer - read
+  // antd's ConfigProvider, which ProTable's `intl` does not feed. With no
+  // provider in the tree they fall back to antd's built-in defaults, which is
+  // how a table outside a ConfigProvider ended up with English ProTable chrome
+  // beside Chinese pagination. Supplying one only in that case makes the
+  // default coherent without relabelling a consumer's own subtree.
+  return antdLocale ? <ConfigProvider locale={antdLocale}>{table}</ConfigProvider> : table;
 };
 
 export default CrudTable;

--- a/lib/CrudTableLazy.tsx
+++ b/lib/CrudTableLazy.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy } from 'react';
 import type { ReactElement } from 'react';
 
 import type { CrudTableConfig } from './CrudTable';
+import { enUS } from './locale/en_US';
 
 /** The generic signature `React.lazy` erases. */
 type CrudTableComponent = <T extends object, K extends keyof T>(
@@ -17,7 +18,11 @@ const LazyCrudTable = lazy(() => import('./CrudTable')) as unknown as CrudTableC
 /** Code-split `CrudTable`, keeping the same typed configuration. */
 const CrudTableLazy = <T extends object, K extends keyof T>(props: CrudTableConfig<T, K>) => (
   <Suspense
-    fallback={<div style={{ textAlign: 'center', padding: '2rem' }}>Loading CRUD table…</div>}
+    fallback={
+      <div style={{ textAlign: 'center', padding: '2rem' }}>
+        {props.locale?.loading ?? enUS.loading}
+      </div>
+    }
   >
     <LazyCrudTable {...props} />
   </Suspense>

--- a/lib/fields/registry.test.tsx
+++ b/lib/fields/registry.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import dayjs from 'dayjs';
 
 import { fieldRegistry, getFieldDefinition } from './registry';
+import { enUS } from '../locale/en_US';
 import type { FieldType } from './registry';
 import type { FieldColumn } from './types';
 
@@ -19,7 +20,7 @@ const column = (overrides: Partial<FieldColumn> = {}): FieldColumn => ({
 /** Invoke a column's render with a record, ignoring ProTable's extra arguments. */
 const renderCell = (fieldType: FieldType, value: unknown, col = column({ fieldType })): ReactNode => {
   const definition = getFieldDefinition(fieldType);
-  const props = definition.column?.(col);
+  const props = definition.column?.(col, enUS);
   if (!props?.render) return null;
   const render = props.render as (
     dom: ReactNode,
@@ -51,7 +52,7 @@ describe('getFieldDefinition', () => {
 
 describe('every field type', () => {
   it.each(ALL_TYPES)('%s exposes a form control (or an explicit null)', (type) => {
-    const control = fieldRegistry[type].formControl(column({ fieldType: type }), false);
+    const control = fieldRegistry[type].formControl(column({ fieldType: type }), false, enUS);
     // `custom` deliberately has no control: it is supplied via formConfig.
     if (type === 'custom') {
       expect(control).toBeNull();
@@ -61,7 +62,7 @@ describe('every field type', () => {
   });
 
   it.each(ALL_TYPES)('%s passes the disabled flag through to its control', (type) => {
-    const control = fieldRegistry[type].formControl(column({ fieldType: type }), true);
+    const control = fieldRegistry[type].formControl(column({ fieldType: type }), true, enUS);
     if (control === null) return;
     expect((control as { props: { disabled?: boolean } }).props.disabled).toBe(true);
   });
@@ -150,7 +151,7 @@ describe('cell rendering', () => {
   });
 
   it('password is excluded from search by default', () => {
-    expect(getFieldDefinition('password').column?.(column())?.search).toBe(false);
+    expect(getFieldDefinition('password').column?.(column(), enUS)?.search).toBe(false);
   });
 
   it('tags renders each entry, and a dash for an empty list', () => {
@@ -201,16 +202,16 @@ describe('cell rendering', () => {
 
 describe('type-implied validation rules', () => {
   it('email and url carry a type rule', () => {
-    expect(getFieldDefinition('email').rules?.(column())).toEqual([
+    expect(getFieldDefinition('email').rules?.(column(), enUS)).toEqual([
       expect.objectContaining({ type: 'email' }),
     ]);
-    expect(getFieldDefinition('url').rules?.(column())).toEqual([
+    expect(getFieldDefinition('url').rules?.(column(), enUS)).toEqual([
       expect.objectContaining({ type: 'url' }),
     ]);
   });
 
   it('json rejects malformed input and accepts valid input', async () => {
-    const [rule] = getFieldDefinition('json').rules?.(column()) ?? [];
+    const [rule] = getFieldDefinition('json').rules?.(column(), enUS) ?? [];
     const validator = (rule as { validator: (r: unknown, v: unknown) => Promise<void> }).validator;
 
     await expect(validator(null, '{"a":1}')).resolves.toBeUndefined();
@@ -218,7 +219,7 @@ describe('type-implied validation rules', () => {
   });
 
   it('json skips validation for empty and non-string values', async () => {
-    const [rule] = getFieldDefinition('json').rules?.(column()) ?? [];
+    const [rule] = getFieldDefinition('json').rules?.(column(), enUS) ?? [];
     const validator = (rule as { validator: (r: unknown, v: unknown) => Promise<void> }).validator;
 
     await expect(validator(null, '')).resolves.toBeUndefined();
@@ -230,7 +231,7 @@ describe('type-implied validation rules', () => {
 describe('column configuration', () => {
   it('marks non-searchable types so they stay out of the search form', () => {
     for (const type of ['rating', 'progress', 'image', 'color', 'json', 'password'] as FieldType[]) {
-      expect(getFieldDefinition(type).column?.(column())?.search).toBe(false);
+      expect(getFieldDefinition(type).column?.(column(), enUS)?.search).toBe(false);
     }
   });
 
@@ -239,10 +240,10 @@ describe('column configuration', () => {
   });
 
   it('maps types onto ProTable valueTypes', () => {
-    expect(getFieldDefinition('money').column?.(column())?.valueType).toBe('money');
-    expect(getFieldDefinition('percent').column?.(column())?.valueType).toBe('percent');
-    expect(getFieldDefinition('textarea').column?.(column())?.valueType).toBe('textarea');
-    expect(getFieldDefinition('time').column?.(column())?.valueType).toBe('time');
+    expect(getFieldDefinition('money').column?.(column(), enUS)?.valueType).toBe('money');
+    expect(getFieldDefinition('percent').column?.(column(), enUS)?.valueType).toBe('percent');
+    expect(getFieldDefinition('textarea').column?.(column(), enUS)?.valueType).toBe('textarea');
+    expect(getFieldDefinition('time').column?.(column(), enUS)?.valueType).toBe('time');
   });
 });
 

--- a/lib/fields/registry.tsx
+++ b/lib/fields/registry.tsx
@@ -4,6 +4,8 @@ import type { FormRule } from 'antd';
 import dayjs from 'dayjs';
 
 import type { EnumOption, FieldColumn } from './types';
+import { enUS } from '../locale/en_US';
+import type { CrudTableLocale } from '../locale/types';
 
 /** Every column type CrudTable understands. */
 export type FieldType =
@@ -36,15 +38,22 @@ export type FieldType =
  */
 export interface FieldTypeDefinition {
   /** Extra ProColumns props merged over the base column (valueType, render, ...). */
-  column?: (col: FieldColumn) => Partial<ProColumns<Record<PropertyKey, unknown>>>;
+  column?: (
+    col: FieldColumn,
+    locale: CrudTableLocale,
+  ) => Partial<ProColumns<Record<PropertyKey, unknown>>>;
   /** The antd control used in the create/edit modal. Return null for "no form field". */
-  formControl: (col: FieldColumn, disabled: boolean) => React.ReactNode | null;
+  formControl: (
+    col: FieldColumn,
+    disabled: boolean,
+    locale: CrudTableLocale,
+  ) => React.ReactNode | null;
   /** Convert a record value into what the form control expects. */
   toFormValue?: (value: unknown) => unknown;
   /** Convert the submitted form value back into the record shape. */
   fromFormValue?: (value: unknown) => unknown;
   /** Validation rules implied by the type itself (merged before user rules). */
-  rules?: (col: FieldColumn) => FormRule[];
+  rules?: (col: FieldColumn, locale: CrudTableLocale) => FormRule[];
   /** Form.Item valuePropName override (e.g. 'checked' for Switch). */
   valuePropName?: string;
 }
@@ -140,11 +149,11 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
   },
 
   date: {
-    column: (col) => ({
+    column: (col, locale) => ({
       valueType: 'dateTime',
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!value) return '-';
+        if (!value) return locale.empty;
         const parsed = dayjs(asText(value));
         return <span>{parsed.isValid() ? parsed.format(DATE_TIME_DISPLAY) : asText(value)}</span>;
       },
@@ -158,11 +167,11 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
   },
 
   boolean: {
-    column: (col) => ({
+    column: (col, locale) => ({
       valueType: 'switch',
       render: (_, record) => (
         <Tag color={cellValue(col, record) ? 'green' : 'red'}>
-          {cellValue(col, record) ? 'Yes' : 'No'}
+          {cellValue(col, record) ? locale.yes : locale.no}
         </Tag>
       ),
     }),
@@ -180,10 +189,10 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
         return option ? <Tag color={option.color}>{option.text}</Tag> : asText(value);
       },
     }),
-    formControl: (col, disabled) => (
+    formControl: (col, disabled, locale) => (
       <Select
         disabled={disabled}
-        placeholder={`Select ${col.title.toLowerCase()}`}
+        placeholder={locale.selectPlaceholder(col.title)}
         options={Object.entries(col.enumOptions || {}).map(([value, option]) => ({
           label: option.text,
           value,
@@ -209,24 +218,24 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
   },
 
   email: {
-    column: (col) => ({
+    column: (col, locale) => ({
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!isPresent(value)) return '-';
+        if (!isPresent(value)) return locale.empty;
         const address = asText(value);
         if (!hasSafeScheme(address, MAIL_SCHEMES)) return <span>{address}</span>;
         return <a href={`mailto:${encodeURIComponent(address)}`}>{address}</a>;
       },
     }),
     formControl: (_col, disabled) => <Input type="email" disabled={disabled} />,
-    rules: () => [{ type: 'email', message: 'Please enter a valid email' }],
+    rules: (_col, locale) => [{ type: 'email', message: locale.invalidEmail }],
   },
 
   url: {
-    column: (col) => ({
+    column: (col, locale) => ({
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!isPresent(value)) return '-';
+        if (!isPresent(value)) return locale.empty;
         const href = asText(value);
         // An unsafe scheme renders as inert text: the value is still visible,
         // it simply is not clickable.
@@ -239,14 +248,14 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
       },
     }),
     formControl: (_col, disabled) => <Input disabled={disabled} />,
-    rules: () => [{ type: 'url', message: 'Please enter a valid URL' }],
+    rules: (_col, locale) => [{ type: 'url', message: locale.invalidUrl }],
   },
 
   password: {
     // Never show the value in the table, and keep it out of search by default
-    column: (col) => ({
+    column: (col, locale) => ({
       search: false,
-      render: (_, record) => (isPresent(cellValue(col, record)) ? '••••••••' : '-'),
+      render: (_, record) => (isPresent(cellValue(col, record)) ? '••••••••' : locale.empty),
     }),
     formControl: (_col, disabled) => <Input.Password disabled={disabled} />,
   },
@@ -307,11 +316,11 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
 
   // Stored as a [startISO, endISO] tuple
   dateRange: {
-    column: (col) => ({
+    column: (col, locale) => ({
       valueType: 'dateRange',
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!Array.isArray(value) || value.length !== 2) return '-';
+        if (!Array.isArray(value) || value.length !== 2) return locale.empty;
         const [start, end] = value.map((v) => dayjs(asText(v)));
         if (!start.isValid() || !end.isValid()) return asText(value);
         return `${start.format(DATE_DISPLAY)} ~ ${end.format(DATE_DISPLAY)}`;
@@ -330,10 +339,10 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
 
   // Stored as string[]
   tags: {
-    column: (col) => ({
+    column: (col, locale) => ({
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!Array.isArray(value) || value.length === 0) return '-';
+        if (!Array.isArray(value) || value.length === 0) return locale.empty;
         return (
           <>
             {value.map((tag) => (
@@ -343,18 +352,18 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
         );
       },
     }),
-    formControl: (_col, disabled) => (
-      <Select mode="tags" open={false} suffixIcon={null} disabled={disabled} placeholder="Type and press enter" />
+    formControl: (_col, disabled, locale) => (
+      <Select mode="tags" open={false} suffixIcon={null} disabled={disabled} placeholder={locale.tagsPlaceholder} />
     ),
   },
 
   // Stored as an image URL
   image: {
-    column: (col) => ({
+    column: (col, locale) => ({
       search: false,
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!isPresent(value)) return '-';
+        if (!isPresent(value)) return locale.empty;
         const src = asText(value);
         if (!isSafeImageSource(src)) return <span>{src}</span>;
         return <Image src={src} width={48} height={48} style={{ objectFit: 'cover' }} />;
@@ -363,16 +372,16 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
     formControl: (_col, disabled) => (
       <Input placeholder="https://..." disabled={disabled} />
     ),
-    rules: () => [{ type: 'url', message: 'Please enter a valid image URL' }],
+    rules: (_col, locale) => [{ type: 'url', message: locale.invalidImageUrl }],
   },
 
   // Stored as a hex string
   color: {
-    column: (col) => ({
+    column: (col, locale) => ({
       search: false,
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (!isPresent(value)) return '-';
+        if (!isPresent(value)) return locale.empty;
         const hex = asText(value);
         return (
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
@@ -400,12 +409,12 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
 
   // Stored as a plain object/array
   json: {
-    column: (col) => ({
+    column: (col, locale) => ({
       search: false,
       ellipsis: true,
       render: (_, record) => {
         const value = cellValue(col, record);
-        if (value === undefined || value === null) return '-';
+        if (value === undefined || value === null) return locale.empty;
         return <Typography.Text code>{JSON.stringify(value)}</Typography.Text>;
       },
     }),
@@ -415,7 +424,7 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
     toFormValue: (value) =>
       typeof value === 'string' ? value : JSON.stringify(value, null, 2),
     fromFormValue: (value) => (typeof value === 'string' && value.trim() !== '' ? JSON.parse(value) : value),
-    rules: () => [
+    rules: (_col, locale) => [
       {
         validator: async (_rule: unknown, value: unknown) => {
           if (value === undefined || value === null || value === '') return;
@@ -423,7 +432,7 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
           try {
             JSON.parse(value);
           } catch {
-            throw new Error('Please enter valid JSON');
+            throw new Error(locale.invalidJson);
           }
         },
       },
@@ -434,5 +443,8 @@ export const fieldRegistry: Record<FieldType, FieldTypeDefinition> = {
 /** Look up a field type, falling back to `string` so every column gets a form control. */
 export const getFieldDefinition = (fieldType?: FieldType): FieldTypeDefinition =>
   fieldRegistry[fieldType ?? 'string'] ?? fieldRegistry.string;
+
+/** The strings a field definition falls back to when a caller passes none. */
+export const defaultFieldLocale: CrudTableLocale = enUS;
 
 export type { EnumOption, FieldColumn };

--- a/lib/hooks/useCrudTable.ts
+++ b/lib/hooks/useCrudTable.ts
@@ -16,6 +16,8 @@ import type {
   RestDataSourceOptions,
 } from '../core';
 import type { CrudOperations } from '../core/CustomDataSource';
+import { enUS } from '../locale/en_US';
+import type { CrudTableLocale, PartialCrudTableLocale } from '../locale/types';
 
 /** The operations a table performs, used to tag success and error callbacks. */
 export type CrudOperationName = 'list' | 'create' | 'update' | 'delete';
@@ -76,6 +78,14 @@ interface UseCrudTableOptionsBase<T, K extends keyof T> {
 
   /** Show antd toasts for the outcome of each operation. */
   notifications?: boolean;
+
+  /**
+   * Overrides for the toast wording.
+   *
+   * `CrudTable` passes its own resolved locale down, so this is only needed
+   * when the hook is used on its own.
+   */
+  locale?: PartialCrudTableLocale;
 
   /** Called after an operation succeeds, with whatever it produced. */
   onSuccess?: (operation: CrudOperationName, payload: unknown) => void;
@@ -194,6 +204,11 @@ export const useCrudTable = <T extends object, K extends keyof T>(
     notifications = true,
   } = options;
 
+  const strings: CrudTableLocale = useMemo(
+    () => (options.locale ? { ...enUS, ...options.locale } : enUS),
+    [options.locale],
+  );
+
   // Read through a ref so callback identity does not change every render.
   // `options` is almost always an object literal at the call site, so
   // depending on it directly recreated every callback on every render and
@@ -286,7 +301,7 @@ export const useCrudTable = <T extends object, K extends keyof T>(
           total: prev.total + 1,
           loading: false,
         }));
-        succeed('create', created, 'Created successfully');
+        succeed('create', created, strings.createSuccess);
         return created;
       } catch (thrown) {
         setState((prev) => ({ ...prev, loading: false }));
@@ -294,7 +309,7 @@ export const useCrudTable = <T extends object, K extends keyof T>(
         return null;
       }
     },
-    [dataSource, reconcile, report, succeed],
+    [dataSource, reconcile, report, succeed, strings],
   );
 
   const update = useCallback(
@@ -307,7 +322,7 @@ export const useCrudTable = <T extends object, K extends keyof T>(
           data: prev.data.map((item) => (item[rowKey] === id ? updated : item)),
           loading: false,
         }));
-        succeed('update', updated, 'Updated successfully');
+        succeed('update', updated, strings.updateSuccess);
         return updated;
       } catch (thrown) {
         setState((prev) => ({ ...prev, loading: false }));
@@ -315,7 +330,7 @@ export const useCrudTable = <T extends object, K extends keyof T>(
         return null;
       }
     },
-    [dataSource, reconcile, report, rowKey, succeed],
+    [dataSource, reconcile, report, rowKey, succeed, strings],
   );
 
   const remove = useCallback(
@@ -329,7 +344,7 @@ export const useCrudTable = <T extends object, K extends keyof T>(
           total: Math.max(0, prev.total - 1),
           loading: false,
         }));
-        succeed('delete', id, 'Deleted successfully');
+        succeed('delete', id, strings.deleteSuccess);
         return true;
       } catch (thrown) {
         setState((prev) => ({ ...prev, loading: false }));
@@ -337,7 +352,7 @@ export const useCrudTable = <T extends object, K extends keyof T>(
         return false;
       }
     },
-    [dataSource, reconcile, report, rowKey, succeed],
+    [dataSource, reconcile, report, rowKey, succeed, strings],
   );
 
   const setPage = useCallback((next: number) => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,8 +56,12 @@ export type {
   Timestamped,
 } from './core';
 
+// Localization
+export { enUS, useResolvedLocale } from './locale';
+export type { CrudTableLocale, PartialCrudTableLocale, ResolvedLocale } from './locale';
+
 // Field-type registry
-export { fieldRegistry, getFieldDefinition } from './fields/registry';
+export { fieldRegistry, getFieldDefinition, defaultFieldLocale } from './fields/registry';
 export type { FieldType, FieldTypeDefinition } from './fields/registry';
 export type { EnumOption, FieldColumn } from './fields/types';
 

--- a/lib/locale/en_US.ts
+++ b/lib/locale/en_US.ts
@@ -1,0 +1,56 @@
+import type { CrudTableLocale } from './types';
+
+/**
+ * The built-in default.
+ *
+ * English is the fallback everywhere, including when no antd `ConfigProvider`
+ * is present - which is the case that previously left antd's own components
+ * rendering their built-in Chinese defaults.
+ */
+export const enUS: CrudTableLocale = {
+  actions: 'Actions',
+  edit: 'Edit',
+  delete: 'Delete',
+  create: 'New',
+  refresh: 'Refresh',
+
+  createTitle: 'Create Item',
+  editTitle: 'Edit Item',
+  ok: 'OK',
+  cancel: 'Cancel',
+  requiredField: (label) => `${label} is required`,
+
+  confirmDeleteTitle: 'Are you sure?',
+  confirmDeleteContent: 'This action cannot be undone.',
+  confirmDeleteOk: 'Yes, Delete',
+  confirmBulkDeleteTitle: (count) => `Delete ${count} items?`,
+  confirmBulkDeleteOk: 'Yes, Delete All',
+  deleteSelected: (count) => `Delete Selected (${count})`,
+  selectItemsToDelete: 'Please select items to delete',
+  bulkDeleteSuccess: (count) => `Deleted ${count} items`,
+  bulkDeletePartial: (succeeded, total, failed) =>
+    `Deleted ${succeeded} of ${total}. ${failed} failed.`,
+
+  exportAll: (format) => `Export all as ${format}`,
+  exportPage: (format) => `Export page as ${format}`,
+  nothingToExport: 'Nothing to export',
+  exportFailed: (message) => `Export failed: ${message}`,
+
+  createSuccess: 'Created successfully',
+  updateSuccess: 'Updated successfully',
+  deleteSuccess: 'Deleted successfully',
+
+  loading: 'Loading CRUD table…',
+
+  yes: 'Yes',
+  no: 'No',
+  empty: '-',
+  selectPlaceholder: (title) => `Select ${title.toLowerCase()}`,
+  tagsPlaceholder: 'Type and press enter',
+  invalidEmail: 'Please enter a valid email',
+  invalidUrl: 'Please enter a valid URL',
+  invalidImageUrl: 'Please enter a valid image URL',
+  invalidJson: 'Please enter valid JSON',
+};
+
+export default enUS;

--- a/lib/locale/index.ts
+++ b/lib/locale/index.ts
@@ -1,0 +1,4 @@
+export { enUS } from './en_US';
+export { useResolvedLocale } from './useResolvedLocale';
+export type { ResolvedLocale } from './useResolvedLocale';
+export type { CrudTableLocale, PartialCrudTableLocale } from './types';

--- a/lib/locale/locale.test.tsx
+++ b/lib/locale/locale.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfigProvider } from 'antd';
+import frFR from 'antd/locale/fr_FR';
+import deDE from 'antd/locale/de_DE';
+
+import CrudTable from '../CrudTable';
+import type { CrudColumn } from '../CrudTable';
+import { enUS } from './en_US';
+
+interface User {
+  id: number;
+  name: string;
+}
+
+const rows: User[] = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+];
+
+const columns: CrudColumn<User>[] = [
+  { dataIndex: 'name', title: 'Name', fieldType: 'string', formConfig: { required: true } },
+];
+
+/**
+ * The most recently opened dialog.
+ *
+ * `Modal` and `Modal.confirm` mount roots outside the tree Testing Library
+ * manages and close with an animation, so a dialog from an earlier test can
+ * still be in the document. Taking the last match targets this test's own.
+ */
+const latestDialog = async (): Promise<HTMLElement> => {
+  const dialogs = await screen.findAllByRole('dialog');
+  return dialogs[dialogs.length - 1];
+};
+
+const table = (props: Partial<Parameters<typeof CrudTable<User, 'id'>>[0]> = {}) => (
+  <CrudTable<User, 'id'>
+    title="Users"
+    rowKey="id"
+    columns={columns}
+    hookConfig={{ staticData: rows }}
+    {...props}
+  />
+);
+
+describe('default locale, with no ConfigProvider', () => {
+  // The regression this exists for: rendered outside a ConfigProvider, antd's
+  // own components fall back to their built-in defaults, which are Chinese.
+  // ProTable's intl does not feed them, so the table showed English chrome
+  // beside Chinese pagination and modal buttons.
+  it('renders antd chrome in English', async () => {
+    render(table());
+    await screen.findByText('Alice');
+
+    const body = document.body.textContent ?? '';
+    expect(body).not.toMatch(/[一-鿿]/);
+  });
+
+  it('labels the library chrome in English', async () => {
+    render(table());
+    await screen.findByText('Alice');
+
+    expect(screen.getByText('Actions')).toBeDefined();
+    expect(screen.getAllByRole('button', { name: 'Edit' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /New/ })).toBeDefined();
+  });
+
+  it('labels the modal footer in English', async () => {
+    const user = userEvent.setup();
+    render(table());
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await latestDialog();
+
+    expect(within(dialog).getByRole('button', { name: 'OK' })).toBeDefined();
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeDefined();
+  });
+});
+
+describe('inheriting a ConfigProvider locale', () => {
+  it('follows the app locale for antd chrome instead of forcing English', async () => {
+    render(<ConfigProvider locale={frFR}>{table()}</ConfigProvider>);
+    await screen.findByText('Alice');
+
+    // ProTable's search form is localised through its intl, which is derived
+    // from the surrounding antd locale.
+    await waitFor(() => expect(screen.getByRole('button', { name: /Rechercher/i })).toBeDefined());
+  });
+
+  it('does not override the consumer ConfigProvider', async () => {
+    render(
+      <ConfigProvider locale={deDE}>
+        <div data-testid="host">{table()}</div>
+      </ConfigProvider>,
+    );
+    await screen.findByText('Alice');
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /Suchen/i })).toBeDefined());
+  });
+});
+
+describe('locale overrides', () => {
+  it('replaces the library strings it is given', async () => {
+    render(
+      table({
+        locale: {
+          actions: 'Aktionen',
+          edit: 'Bearbeiten',
+          delete: 'Löschen',
+          create: 'Neu',
+        },
+      }),
+    );
+    await screen.findByText('Alice');
+
+    expect(screen.getByText('Aktionen')).toBeDefined();
+    expect(screen.getAllByRole('button', { name: 'Bearbeiten' }).length).toBe(2);
+    expect(screen.getByRole('button', { name: /Neu/ })).toBeDefined();
+  });
+
+  it('falls back to English for strings it is not given', async () => {
+    render(table({ locale: { actions: 'Aktionen' } }));
+    await screen.findByText('Alice');
+
+    expect(screen.getByText('Aktionen')).toBeDefined();
+    // Not overridden, so still the default.
+    expect(screen.getAllByRole('button', { name: 'Edit' }).length).toBe(2);
+  });
+
+  it('uses overridden wording in the delete confirmation', async () => {
+    const user = userEvent.setup();
+    render(
+      table({
+        locale: {
+          confirmDeleteTitle: 'Wirklich löschen?',
+          confirmDeleteOk: 'Ja, löschen',
+        },
+      }),
+    );
+    await screen.findByText('Alice');
+
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+
+    expect((await screen.findAllByText('Wirklich löschen?')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByRole('button', { name: /Ja, löschen/ })).length).toBeGreaterThan(0);
+  });
+
+  it('uses overridden wording for interpolated strings', async () => {
+    const user = userEvent.setup();
+    render(
+      table({
+        enableBulkOperations: true,
+        locale: { deleteSelected: (count) => `${count} entfernen` },
+      }),
+    );
+    await screen.findByText('Alice');
+
+    await user.click(screen.getAllByRole('checkbox')[0]);
+
+    expect(await screen.findByRole('button', { name: '2 entfernen' })).toBeDefined();
+  });
+
+  it('uses overridden wording for export menu entries', async () => {
+    const user = userEvent.setup();
+    render(table({ locale: { exportAll: (format) => `Tout exporter en ${format}` } }));
+    await screen.findByText('Alice');
+
+    await user.hover(screen.getByRole('button', { name: 'ellipsis' }));
+
+    expect(await screen.findByText('Tout exporter en CSV')).toBeDefined();
+  });
+
+  it('uses overridden validation wording', async () => {
+    const user = userEvent.setup();
+    render(table({ locale: { requiredField: (label) => `${label} fehlt` } }));
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await latestDialog();
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    expect((await screen.findAllByText('Name fehlt')).length).toBeGreaterThan(0);
+  });
+});
+
+describe('enUS default', () => {
+  it('supplies every key the contract declares', () => {
+    // A missing key would surface as `undefined` in the UI rather than a
+    // compile error, since overrides are partial by design.
+    for (const [key, value] of Object.entries(enUS)) {
+      expect(value, `enUS.${key} is missing`).toBeDefined();
+      expect(['string', 'function']).toContain(typeof value);
+    }
+  });
+
+  it('interpolates counts and labels', () => {
+    expect(enUS.requiredField('Name')).toBe('Name is required');
+    expect(enUS.confirmBulkDeleteTitle(3)).toBe('Delete 3 items?');
+    expect(enUS.bulkDeletePartial(6, 10, 4)).toBe('Deleted 6 of 10. 4 failed.');
+    expect(enUS.exportAll('CSV')).toBe('Export all as CSV');
+    expect(enUS.selectPlaceholder('Status')).toBe('Select status');
+  });
+});
+
+describe('hook toasts', () => {
+  it('uses the resolved locale for success messages', async () => {
+    const user = userEvent.setup();
+    const { message } = await import('antd');
+    const success = vi.spyOn(message, 'success');
+
+    render(table({ locale: { createSuccess: 'Créé avec succès' } }));
+    await screen.findByText('Alice');
+
+    await user.click(screen.getByRole('button', { name: /New/ }));
+    const dialog = await latestDialog();
+    await user.type(within(dialog).getAllByRole('textbox')[0], 'Carol');
+    await user.click(within(dialog).getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => expect(success).toHaveBeenCalledWith('Créé avec succès'));
+  });
+});

--- a/lib/locale/types.ts
+++ b/lib/locale/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Every user-visible string the library produces.
+ *
+ * Interpolated strings are functions rather than templates with placeholders,
+ * so a translation cannot silently drop a value or get the argument order
+ * wrong - the compiler checks it.
+ *
+ * antd's own chrome (pagination, empty states, date pickers) is localised
+ * through antd's `ConfigProvider`, and ProTable's chrome through its `intl`.
+ * `CrudTable` derives both from the surrounding `ConfigProvider` when there is
+ * one, so a consumer usually sets their app locale once and this object only
+ * needs supplying to override the library's own wording.
+ */
+export interface CrudTableLocale {
+  /** Header of the per-row actions column. */
+  actions: string;
+  /** Row action opening the edit form. */
+  edit: string;
+  /** Row action deleting a record. */
+  delete: string;
+  /** Toolbar button opening the create form. */
+  create: string;
+  /** Toolbar menu entry re-reading the current page. */
+  refresh: string;
+
+  /** Title of the create form. */
+  createTitle: string;
+  /** Title of the edit form. */
+  editTitle: string;
+  /** Confirm button in the create/edit form. */
+  ok: string;
+  /** Dismiss button in the create/edit form. */
+  cancel: string;
+  /** Validation message for a required field. */
+  requiredField: (label: string) => string;
+
+  /** Title of the single-delete confirmation. */
+  confirmDeleteTitle: string;
+  /** Body of both delete confirmations. */
+  confirmDeleteContent: string;
+  /** Confirm button of the single-delete confirmation. */
+  confirmDeleteOk: string;
+  /** Title of the bulk-delete confirmation. */
+  confirmBulkDeleteTitle: (count: number) => string;
+  /** Confirm button of the bulk-delete confirmation. */
+  confirmBulkDeleteOk: string;
+  /** Toolbar button opening the bulk-delete confirmation. */
+  deleteSelected: (count: number) => string;
+  /** Warning shown when bulk delete is invoked with nothing selected. */
+  selectItemsToDelete: string;
+  /** Result message when every delete in a bulk run succeeded. */
+  bulkDeleteSuccess: (count: number) => string;
+  /** Result message when only some deletes in a bulk run succeeded. */
+  bulkDeletePartial: (succeeded: number, total: number, failed: number) => string;
+
+  /** Menu entry writing every matching record. */
+  exportAll: (format: string) => string;
+  /** Menu entry writing only the rows on screen. */
+  exportPage: (format: string) => string;
+  /** Warning shown when there is nothing to write. */
+  nothingToExport: string;
+  /** Error shown when gathering or writing the export failed. */
+  exportFailed: (message: string) => string;
+
+  /** Confirmation that a record was created. */
+  createSuccess: string;
+  /** Confirmation that a record was updated. */
+  updateSuccess: string;
+  /** Confirmation that a record was deleted. */
+  deleteSuccess: string;
+
+  /** Placeholder while the code-split table loads. */
+  loading: string;
+
+  /** Cell text for a true boolean. */
+  yes: string;
+  /** Cell text for a false boolean. */
+  no: string;
+  /** Cell text for a missing value. */
+  empty: string;
+  /** Placeholder of an enum column's select control. */
+  selectPlaceholder: (title: string) => string;
+  /** Placeholder of a tags column's input. */
+  tagsPlaceholder: string;
+  /** Validation message for an `email` column. */
+  invalidEmail: string;
+  /** Validation message for a `url` column. */
+  invalidUrl: string;
+  /** Validation message for an `image` column. */
+  invalidImageUrl: string;
+  /** Validation message for a `json` column. */
+  invalidJson: string;
+}
+
+/** A locale override: supply only the strings that differ from the default. */
+export type PartialCrudTableLocale = Partial<CrudTableLocale>;

--- a/lib/locale/useResolvedLocale.ts
+++ b/lib/locale/useResolvedLocale.ts
@@ -1,0 +1,68 @@
+import { useContext, useMemo } from 'react';
+import { ConfigProvider } from 'antd';
+import type { Locale as AntdLocale } from 'antd/es/locale';
+import antdEnUS from 'antd/locale/en_US';
+import { enUSIntl, intlMap, findIntlKeyByAntdLocaleKey } from '@ant-design/pro-components';
+
+import { enUS } from './en_US';
+import type { CrudTableLocale, PartialCrudTableLocale } from './types';
+
+/** Everything `CrudTable` needs to render in the right language. */
+export interface ResolvedLocale {
+  /** The library's own strings, defaults merged with any override. */
+  strings: CrudTableLocale;
+  /** ProTable's message bundle, derived from the surrounding antd locale. */
+  intl: typeof enUSIntl;
+  /**
+   * The antd locale to apply, or `undefined` to inherit.
+   *
+   * `undefined` means the consumer already has a `ConfigProvider`, so the
+   * table must not override it. A value means there is none, and antd's
+   * components would otherwise fall back to their built-in defaults - which
+   * are Chinese, not English.
+   */
+  antdLocale: AntdLocale | undefined;
+  /** Whether an antd `ConfigProvider` locale was found in the tree. */
+  inherited: boolean;
+}
+
+/**
+ * Resolve the language for a table from three sources, in order.
+ *
+ * 1. An explicit `locale` prop, for overriding individual strings.
+ * 2. The surrounding antd `ConfigProvider`, so a table follows the app.
+ * 3. English, when there is no provider at all.
+ *
+ * Step 3 is the one that matters most in practice. antd's components read
+ * their own `ConfigProvider`, which `ProConfigProvider`'s `intl` does not
+ * feed, so a table rendered outside any provider showed English chrome from
+ * ProTable next to Chinese pagination and modal buttons from antd. Supplying
+ * an explicit antd locale in that case is what makes the default coherent.
+ */
+export const useResolvedLocale = (override?: PartialCrudTableLocale): ResolvedLocale => {
+  const config = useContext(ConfigProvider.ConfigContext);
+  const inheritedLocale = config.locale;
+
+  return useMemo(() => {
+    const strings: CrudTableLocale = override ? { ...enUS, ...override } : enUS;
+
+    // ProTable keys its bundles by IETF tag; antd locales carry a shorter key
+    // (`en`, `fr`, `zh-cn`) that pro-components maps for us.
+    // `findIntlKeyByAntdLocaleKey` returns a plain string, so the lookup is
+    // narrowed against the map's own keys rather than indexed blindly.
+    const intlKey = inheritedLocale?.locale
+      ? findIntlKeyByAntdLocaleKey(inheritedLocale.locale)
+      : undefined;
+    const isKnownIntlKey = (key: string): key is keyof typeof intlMap => key in intlMap;
+    const intl = intlKey && isKnownIntlKey(intlKey) ? intlMap[intlKey] : enUSIntl;
+
+    return {
+      strings,
+      intl,
+      // Only supply a locale when nothing above us did; overriding a
+      // consumer's ConfigProvider would relabel their whole subtree.
+      antdLocale: inheritedLocale ? undefined : antdEnUS,
+      inherited: Boolean(inheritedLocale),
+    };
+  }, [override, inheritedLocale]);
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       // tested code. The component and registry suites then took it from
       // 54% to 87%.
       thresholds: {
-        statements: 87,
-        branches: 79,
-        functions: 88,
-        lines: 88,
+        statements: 91,
+        branches: 82,
+        functions: 92,
+        lines: 92,
       },
     },
   },


### PR DESCRIPTION
## The bug, caught on the live site

The deployed Storybook showed this under an otherwise English table:

```
1-5 of 23 items    [1] [2] [3] [4] [5]    5 条/页    跳至页
```

`CrudTable` pinned ProTable to `enUSIntl` and hardcoded its own wording — but **ProTable's `intl` does not reach plain antd components**. Pagination, empty states, date pickers and the modal footer all read antd's own `ConfigProvider`. With no provider in the tree they fall back to antd's built-in defaults, which are Chinese.

The demo app hid this because `App.tsx` wraps everything in `<ConfigProvider locale={enUS}>`. Storybook has no such wrapper, so it surfaced there — and it surfaces for any consumer who doesn't happen to have a provider.

## Resolution order

1. An explicit `locale` prop
2. The surrounding antd `ConfigProvider`, with ProTable's bundle derived from the antd locale key via `findIntlKeyByAntdLocaleKey`
3. English

**Step 3 is the part that was missing.** A `ConfigProvider` carrying antd's English locale is now supplied *only when nothing above the table did* — so the default is coherent, without relabelling a consumer's own subtree when they already have a provider.

```tsx
return antdLocale ? <ConfigProvider locale={antdLocale}>{table}</ConfigProvider> : table;
```

## The locale contract

`CrudTableLocale` covers all ~40 strings: actions column, row and toolbar buttons, both delete confirmations, export menu, validation messages, the registry's `Yes`/`No`/`-`/placeholders, and the hook's toasts.

Interpolated strings are **functions, not templates with placeholders**:

```ts
deleteSelected: (count: number) => string;
bulkDeletePartial: (succeeded: number, total: number, failed: number) => string;
```

A translation therefore cannot silently drop a value or reorder its arguments — the compiler checks it. Overrides are partial; anything omitted stays English.

Field definitions receive the resolved strings, so a registry entry no longer hardcodes `Yes` or `Please enter valid JSON`. That extends `FieldTypeDefinition`'s hooks with a `locale` argument — only relevant to code registering custom field types.

## Tests

14 new cases, including the three that matter most:

- rendered with **no** `ConfigProvider`, the DOM contains no CJK characters at all
- wrapped in `frFR`/`deDE`, the chrome follows the app rather than being forced to English
- partial overrides apply, and un-overridden keys stay English

## Verification

```
pnpm lint       0 problems
pnpm test       253 passed  (was 239)
coverage        91.05% statements  (thresholds raised)
build:lib       ok
build:site      ok
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>