### PR TITLE
[version]: set version to `0.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@ All notable changes to this project are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-30
+
+### Added
+
+- **Full localization.** Every user-visible string is overridable through a
+  `locale` prop typed by `CrudTableLocale`, with `enUS` as the exported default.
+  Interpolated strings are functions rather than templates with placeholders, so
+  a translation cannot drop a value or reorder its arguments.
+- The table follows the surrounding antd `ConfigProvider`, deriving ProTable's
+  message bundle from the app locale instead of pinning it to English.
+- `FieldTypeDefinition` hooks receive the resolved strings, so registry entries
+  no longer hardcode `Yes`, `-` or their validation messages.
+- Analytics are injected into every generated page of the deployed site. The
+  demo carried a tag by hand; the 68 TypeDoc pages and Storybook did not.
+
+### Fixed
+
+- **antd chrome fell back to Chinese when no `ConfigProvider` was present.**
+  ProTable's `intl` does not reach plain antd components — pagination, empty
+  states and the modal footer read antd's own provider. Without one they used
+  antd's built-in defaults. The table now supplies English in exactly that case,
+  without overriding a consumer's provider when they have one.
+- Storybook's deployed build requested assets from the domain root rather than
+  the project subpath, so no story loaded on GitHub Pages.
+- Removed a favicon link pointing at a file that does not exist.
+
+### Documentation
+
+- README rewritten for the current API. It still described the 0.5.x surface and
+  carried two "API Reference" sections that had drifted apart; 904 lines to 376.
+
 ## [0.6.0] - 2026-08-30
+
+> Never published to npm — the release workflows were disabled while this work
+> was verified locally. Everything below ships as part of 0.7.0.
 
 A breaking release. See [MIGRATION.md](./MIGRATION.md) — every break is a
 compile error rather than a silent behaviour change.
@@ -113,4 +147,4 @@ compile error rather than a silent behaviour change.
 - Testing Library's cleanup was never registering, so renders accumulated
   across tests in the same file.
 
-[0.6.0]: https://github.com/maifeeulasad/antd-crud-table/releases/tag/v0.6.0
+[0.7.0]: https://github.com/maifeeulasad/antd-crud-table/releases/tag/v0.7.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "antd-crud-table",
   "private": false,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "homepage": "https://github.com/maifeeulasad/antd-crud-table",
   "repository": {


### PR DESCRIPTION
Ships everything from the audit backlog plus localization. **Carries the 0.6.0 work too** — that version was set in the manifest but never published, since the release workflows were disabled while it was verified locally. The changelog says so rather than leaving an unexplained gap between `0.5.0` on npm and `0.7.0`.

## Since 0.5.0

**Security** — CSV/Excel formula injection; `javascript:` URLs in link and image columns.

**Correctness** — double list request per mutation; `onError` silent on the list path; inline `staticData` discarding rows; duplicate IDs for non-numeric keys; search clobbering column filters; bulk delete reporting success on failure; `enableColumnSettings` never implemented; export writing only the visible page; Chinese modal buttons and pagination.

**Architecture** — `CrudDataSource<T, K>` with four class strategies; `any` eliminated from the public API, `no-explicit-any` now an error.

**Localization** — every string overridable, follows the app's `ConfigProvider`, English when there is none.

**Tooling** — coverage gate, TypeDoc, Storybook, combined site build, React 19, site-wide analytics.

## Numbers

```
                 0.5.0      0.7.0
Tests               25    →    268
Coverage         42.5%    →   91.1% statements
Lint warnings       49    →      0   (`any` is now an error)
README            904 L   →   376 L  (and accurate)
```

## Verification

```
pnpm lint          0 problems
pnpm test          268 passed
pnpm test:coverage passes at enforced thresholds
pnpm build:lib     ok
pnpm build:site    ok, 71 pages tagged
CI                 green on React 18 and 19
Pages              demo, storybook and API reference verified live
```

Merging this, then cutting the `v0.7.0` release to publish to npm.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>